### PR TITLE
Fix crash due to change in TcRawDataPacket definition

### DIFF
--- a/GenerateEmpRxFile.cpp
+++ b/GenerateEmpRxFile.cpp
@@ -109,9 +109,9 @@ int main() {
       for(unsigned up(0);up<TPGStage1Emulation::Stage1IOFwCfg::MaximumUnpackersPerLpgbtPair;up++) {
         if(fwCfg.connected(lp,up)) {
 	  connected=true;
-	  vTc.second.resize(0);
+	  //vTc.resize(0);
 
-	  TPGFEDataformat::TcRawData::Type type=fwCfg.type(lp,up);
+	  TPGFEDataformat::Type type=fwCfg.type(lp,up);
 	  unsigned nTc=fwCfg.numberOfTCs(lp,up);
 
 	  //if(lp==0) std::srand(0x12345678);
@@ -120,14 +120,14 @@ int main() {
 
 	  std::cout << std::endl << "lp,up = " << lp << ", " << up
 		    << ", TCs generated" << std::endl;
-	  for(unsigned i(0);i<vTc.second.size();i++) vTc.second[i].print();
+    vTc.print();
 	
 	  TPGFEModuleEmulation::ECONTEmulation::convertToElinkData(bxi,vTc,vEl.data()+fwCfg.firstElink(lp,up));
 	
 	  if(ibx==0 && lp==0) {
 	    std::cout << std::endl << "ECONT " << up << std::endl;
-	    for(unsigned i(0);i<vTc.second.size();i++) vTc.second[i].print();
-	    std::cout << std::hex << std::setfill('0');
+	    vTc.print();
+      std::cout << std::hex << std::setfill('0');
 	    for(unsigned i(0);i<vEl.size();i++) {
 	      std::cout << " 0x" << vEl[i];
 	    }

--- a/TPGFEModuleEmulation.hh
+++ b/TPGFEModuleEmulation.hh
@@ -601,7 +601,7 @@ namespace TPGFEModuleEmulation{
           data=(data<<32);
           last+=32;
         }
-        
+
         if     (tcType==TPGFEDataformat::BestC) last-=6;
         else if(tcType==TPGFEDataformat::STC4A) last-=2;
         else if(tcType==TPGFEDataformat::STC4B) last-=2;
@@ -679,15 +679,16 @@ namespace TPGFEModuleEmulation{
     
     //std::vector<TPGFEDataformat::TcRawData> &vtc(vtcrp.second);
     std::vector<TPGFEDataformat::TcRawData> &vtc(vtcrp.setTcData());
+    vtcrp.setType(type);
   
     if(type==TPGFEDataformat::BestC) {
-      // vtc.resize(nTc+1);
-      // vtc[0].setModuleSum(zero?0:rand()&0xff);
+      vtc.resize(nTc);
+      vtcrp.setModuleSum(zero?0:rand()&0xff);
     
       unsigned step(48/nTc);
       //for(unsigned i(1);i<vtc.size();i++) {
       for(unsigned i(0);i<vtc.size();i++) {
-	vtc[i].setTriggerCell(type,step*(i-1)+(rand()%step),zero?0:rand()&0x7f);
+	      vtc[i].setTriggerCell(type,step*(i)+(rand()%step),zero?0:rand()&0x7f);
       }
     
     } else if(type==TPGFEDataformat::STC4A) {


### PR DESCRIPTION
A recent change in the definition of TcRawDataPacket led to compilation errors in `GenerateEmpRxFile.cpp`, as well as crashes when generating and converting data; this is a fix for that.

I checked that the modified `GenerateEmpRxFile.cpp` compiles (using ```g++ -I TPGStage1Emulation -I. GenerateEmpRxFile.cpp -L /opt/local/lib -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o GenerateEmpRxFile.exe```) & runs (and does not appear to be producing nonsense) - if you spot any possible other dependencies that should be tested, let me know!

(context: I borrowed code from GenerateEmpRxFile for setting up some code that does data generation->unpacker->TC processor emulator. That code is currently based on Paul's branch but I wanted to update to main, and that would also need this fix :-) )