### PR TITLE
Fix + documentation TestUnpacerTCProcInterface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,8 @@ dump_event.exe: test-beam_Aug24_macros/dump_event.cpp inc/*.*  TPGFEEmulation/*.
 GenerateEmpRxFile.exe: TPGStage1Emulation/GenerateEmpRxFile.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS)  TPGStage1Emulation/GenerateEmpRxFile.cpp  -l yaml-cpp `root-config --libs --cflags` -o GenerateEmpRxFile.exe
 
+TestUnpackerTCProcInterface.exe: TestUnpackerTCProcInterface.cpp *.hh *.h TPGStage1Emulation/*.hh common/inc/*.h
+	g++ -I TPGStage1Emulation -I. HGCalLayer1PhiOrderFwImpl.cc -I. TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o TestUnpackerTCProcInterface.exe
+
 clean:
 	rm *.exe

--- a/README.md
+++ b/README.md
@@ -151,3 +151,16 @@ FileReader::close() closing file dat/Relay1695733045/Run1695733046_Link0_File000
 [idas@lxplus915 hgcal-tpg-fe]$
 
 ```
+
+### Testing running the TC processor on the unpacker output
+
+After compilation, this can be run as
+
+`./TestUnpackerTCProcInterface.exe`
+
+The code will,
+1. Generate some raw TC data (as in `GenerateEmpRxFile.cpp`). For simplicity only one BX is considered.
+2. Converts the raw TC data to `UnpackerOutputStreamPair`s
+3. Converts `UnpackerOutputStreamPair` objects to `HGCalTriggerCellSA` objects - these are identical to what is used in CMSSW. Some of the variables of the TC objects are not filled; the phi variable used in simulation is filled with the TC address. A module ID is assigned to each module; the TC object carries this information as well.
+4. A mapping is created that defines TC/column budgets for the different module IDs (mapping based on budgets for different mod types). This, together with the `HGCalTriggerCellSA`s, is used as input to the TC processor emulator.
+5. The TC processor emulator runs, orders the TCs in each module by address, and assigns a column/channel/frame combination to each TC (channel/frame always 0 for the moment). The output of the TC processor emulator is a new, ordered collection of `HGCalTriggerCellSA`s, with additional information stored in the column/channel/frame variables. The information stored in this TC collection is also printed to screen.

--- a/TPGStage1Emulation/TestUnpackerTCProcInterface.cpp
+++ b/TPGStage1Emulation/TestUnpackerTCProcInterface.cpp
@@ -21,12 +21,6 @@ l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDa
   l1thgcfirmware::HGCalTriggerCellSACollection theTCVec;
   for (auto& up : upVec){
       unsigned theModId_ = up.getModuleId();
-      unsigned subPerTC = 0;
-      if(theModId_%5==2){//if STC4, need to subtract 4*nTC from channel no to get address
-          subPerTC = 4;
-      } else if(theModId_%5==3||theModId_%5==4){//if STC16, need to subtract 16*nTC from channel no to get address
-          subPerTC = 16;
-      }
       //std::cout<<"Module ID "<<theModId_<<" subtract per TC "<<subPerTC<<std::endl;
       //std::cout<<"Number of valid channels "<<up.numberOfValidChannels()<<std::endl;
       unsigned nChans_ = up.numberOfValidChannels();
@@ -40,7 +34,7 @@ l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDa
             nTC = (iChn-nStream)/2;
             //std::cout<<"for TC in iChn "<<iChn<<" nStream "<<nStream<<" nTC "<<nTC<<std::endl;
         }
-        theTCVec.emplace_back(1,1,0,up.channelNumber(nStream,nTC)-iChn*subPerTC,0,up.unpackedChannelEnergy(nStream,nTC));
+        theTCVec.emplace_back(1,1,0,up.channelNumber(nStream,nTC),0,up.unpackedChannelEnergy(nStream,nTC));
         theTCVec.back().setModuleId(theModId_);
 
         //std::cout<<"number "<<up.channelNumber(nStream,nTC)<<" address "<<up.channelNumber(nStream,nTC)-iChn*subPerTC<<" unpacked energy "<<up.unpackedChannelEnergy(nStream,nTC)<<std::endl;


### PR DESCRIPTION
This fixes the sorting in `TestUnpackerTCProcInterface` (now sorts TCs by the channel number (=raw address+TC number) from `UnpackerOutputStreamPair`), and adds the items requested in #17.

No example macro provided as the code runs standalone for the moment.