### PR TITLE
Make sure setup script relinks dat directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,11 +31,13 @@ cd $CURRDIR
 rsync -avP $downloaddir/hgcal10glinkreceiver/common .
 #rsync -avP $downloadir/slow_control_configuration cfgmap/
 
-if [ ! -L dat ] ; then
-    if [ $islxplus -eq 1 ] ; then
-	ln -s /eos/cms/store/group/dpg_hgcal/tb_hgcal/2024/BeamTestAug/HgcalBeamtestAug2024 dat
-    fi
-    if [ $ishgcbeamtestpc -eq 1 ] ;  then
-	ln -s /till/HgcalBeamtest2024_TEST dat
-    fi
+if [ -L dat ] ; then
+    unlink dat
+fi
+
+if [ $islxplus -eq 1 ] ; then
+    ln -s /eos/cms/store/group/dpg_hgcal/tb_hgcal/2024/BeamTestAug/HgcalBeamtestAug2024 dat
+fi
+if [ $ishgcbeamtestpc -eq 1 ] ;  then
+    ln -s /till/HgcalBeamtest2024_TEST dat
 fi


### PR DESCRIPTION
Updating an older checkout of the repository and re-running the setup script works fine, but doesn't change the dat symlink, suggestion in this PR is to always unlink when running setup.sh to ensure the dat directory is up to date. 

On a related note, I found `emul_Jul24` doesn't exit with a clear error message when you try to read a file that doesn't exist - though it is clear no correct output is produced. Since it's not the most important thing, I will maybe address that later IFF I'm motivated and there are not more urgent things to do.