### PR TITLE
Emulation updates for STC4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 LDFLAGS=-L$(HOME)/Software/yaml-cpp/lib64
 CPPFLAGS=-I$(HOME)/Software/yaml-cpp/include -I common/inc -I inc -I TPGStage1Emulation/ -I TPGFEEmulation/ -I`root-config --incdir` 
 
-all: emul_Sep24.exe #findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
+all: dump_event.exe emul_Sep24.exe #findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
 
 emul_test-beam_Sep23.exe:  test-beam_Sep23_macros/emul_test-beam_Sep23.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep23_macros/emul_test-beam_Sep23.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_test-beam_Sep23.exe

--- a/TPGFEEmulation/TPGFEConfiguration.hh
+++ b/TPGFEEmulation/TPGFEConfiguration.hh
@@ -518,6 +518,7 @@ namespace TPGFEConfiguration{
     void readEconTConfigYaml(uint32_t idx);
     
     void setPedThZero(); //set the pedestal and thresholds to zero
+    void setPedZero(); //set only the ped values to zero keep the other roc config values as loaded from config
     
     //getters
     const uint32_t getSiModNhroc(std::string typecode) { return  SiModNhroc[typecode];}
@@ -815,7 +816,8 @@ namespace TPGFEConfiguration{
   }
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   void Configuration::loadMuxMapping(){
-    uint32_t type_F_muxmap[48] = {3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12, 19, 18, 17, 16, 23, 22, 21, 20, 27, 26, 25, 24, 31, 30, 29, 28, 35, 34, 33, 32, 39, 38, 37, 36, 43, 42, 41, 40, 47, 46, 45, 44};
+    //uint32_t type_F_muxmap[48] = {3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12, 19, 18, 17, 16, 23, 22, 21, 20, 27, 26, 25, 24, 31, 30, 29, 28, 35, 34, 33, 32, 39, 38, 37, 36, 43, 42, 41, 40, 47, 46, 45, 44};
+    uint32_t type_F_muxmap[48] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
     for(uint32_t itc=0;itc<48;itc++) refMuxMap[itc] = type_F_muxmap[itc];
       
   }
@@ -1119,7 +1121,15 @@ namespace TPGFEConfiguration{
     }
     
   }
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  void Configuration::setPedZero(){
+    
+    for(auto const& hrocch : hrocchcfg)
+      hrocchcfg[hrocch.first].setAdcpedestal(0);
+        
+  }
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   void Configuration::printCfgPedTh(uint32_t moduleId){
     
     for(auto const& hroc : hroccfg){

--- a/inc/TPGFEDataformat.hh
+++ b/inc/TPGFEDataformat.hh
@@ -406,12 +406,18 @@ namespace TPGFEDataformat{
     }
     static struct{
       bool operator()(TPGFEDataformat::TcRawData& a, TPGFEDataformat::TcRawData& b) const { return a.address() < b.address(); }
-    } customLT;
+    } customLTA;
     static struct {
       bool operator()(TPGFEDataformat::TcRawData& a, TPGFEDataformat::TcRawData& b) const { return a.address() > b.address(); }
-    } customGT;
+    } customGTA;
+    static struct{
+      bool operator()(TPGFEDataformat::TcRawData& a, TPGFEDataformat::TcRawData& b) const { return a.energy() < b.energy(); }
+    } customLTE;
+    static struct {
+      bool operator()(TPGFEDataformat::TcRawData& a, TPGFEDataformat::TcRawData& b) const { return a.energy() > b.energy(); }
+    } customGTE;
         
-    void sortCh() {std::sort(setTcData().begin(), setTcData().end(), customLT);}    
+    void sortCh() {std::sort(setTcData().begin(), setTcData().end(), customLTA);}    
     friend std::ostream& operator<<(std::ostream& os, TcRawDataPacket const& atcp){
       return os << "TPGFEDataformat::TcRawDataPacket(" << atcp << ")::print(): "
 		<< "type = " << atcp.typeName()


### PR DESCRIPTION
1. If the energies are tied among TCs for a given STC, select the one with lowest address among them (my experience with the last test-beam data was opposite, to select the highest)
2. In case of fixed ADC pattern run (i.e. Relay 1726581356) the Adc_TH of the ROCs is probably remained in the previous state of trimmed values, so we need to consider this effect in emulation. 

Thanks Danny ([@dnoonan08](https://github.com/dnoonan08)) for explaining the first point.