### PR TITLE
Include S1 TC processor emulator in Jul24 testbeam code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ validation_lpGBTs.exe: test-beam_Aug24_macros/validation_lpGBTs.cpp inc/*.*  TPG
 	g++ -I common/inc -I inc test-beam_Aug24_macros/validation_lpGBTs.cpp  -l yaml-cpp `root-config --libs --cflags` -o validation_lpGBTs.exe
 
 emul_Jul24.exe: test-beam_Aug24_macros/emul_Jul24.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
-	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Aug24_macros/emul_Jul24.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_Jul24.exe -lm
+	g++ $(LDFLAGS) -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc $(CPPFLAGS) test-beam_Aug24_macros/emul_Jul24.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_Jul24.exe -lm
 
 emul_Sep24.exe: test-beam_Sep24_macros/emul_Sep24.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep24_macros/emul_Sep24.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_Sep24.exe -lm
@@ -28,8 +28,8 @@ dump_event.exe: test-beam_Aug24_macros/dump_event.cpp inc/*.*  TPGFEEmulation/*.
 GenerateEmpRxFile.exe: TPGStage1Emulation/GenerateEmpRxFile.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS)  TPGStage1Emulation/GenerateEmpRxFile.cpp  -l yaml-cpp `root-config --libs --cflags` -o GenerateEmpRxFile.exe
 
-TestUnpackerTCProcInterface.exe: TestUnpackerTCProcInterface.cpp *.hh *.h TPGStage1Emulation/*.hh common/inc/*.h
-	g++ -I TPGStage1Emulation -I. HGCalLayer1PhiOrderFwImpl.cc -I. TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o TestUnpackerTCProcInterface.exe
+TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.cpp TPGFEEmulation/*.hh *.h TPGStage1Emulation/*.hh common/inc/*.h
+	g++ -I TPGStage1Emulation/ -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc -I. -I common/inc -I inc -I TPGFEEmulation/ TPGStage1Emulation/TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o TestUnpackerTCProcInterface.exe
 
 clean:
 	rm *.exe

--- a/TPGFEEmulation/TPGFEConfiguration.hh
+++ b/TPGFEEmulation/TPGFEConfiguration.hh
@@ -508,6 +508,7 @@ namespace TPGFEConfiguration{
     void readSciChMapping();
     void loadModIdxToNameMapping();
     void loadMuxMapping();
+    void loadMuxMappingJul24(); //Hack, but needed to not break Jul24 testbeam script
     
     //Read the ROC/ECOND/ECONT configs from yaml file
     void readRocConfigYaml(const std::string& moduletype);
@@ -821,6 +822,11 @@ namespace TPGFEConfiguration{
     for(uint32_t itc=0;itc<48;itc++) refMuxMap[itc] = type_F_muxmap[itc];
       
   }
+  void Configuration::loadMuxMappingJul24(){
+    uint32_t type_F_muxmap[48] = {3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12, 19, 18, 17, 16, 23, 22, 21, 20, 27, 26, 25, 24, 31, 30, 29, 28, 35, 34, 33, 32, 39, 38, 37, 36, 43, 42, 41, 40, 47, 46, 45, 44};
+    for(uint32_t itc=0;itc<48;itc++) refMuxMap[itc] = type_F_muxmap[itc];
+  }
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   void Configuration::readRocConfigYaml(const std::string& modName)
   {

--- a/TPGFEEmulation/TPGFEModuleEmulation.hh
+++ b/TPGFEEmulation/TPGFEModuleEmulation.hh
@@ -148,10 +148,13 @@ namespace TPGFEModuleEmulation{
     
     //The following emulation function performs 1) decompression, 2) calibration, 3) compression
     void Emulate(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&, TPGFEDataformat::TcModulePacket& );
+    void EmulateJulTB(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&, TPGFEDataformat::TcModulePacket& );
     void EmulateSTC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&);
+    void EmulateJulSTC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&);
     void EmulateBC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&);
     
     void Emulate(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&);
+    void EmulateJulTB(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>&);
     const TPGFEDataformat::TcModulePacket& getTcRawDataPacket() const {return emulOut;}
     TPGFEDataformat::TcModulePacket& accessTcRawDataPacket() {return emulOut;}
     void setVerbose(bool verbose = true) {isVerbose = verbose;}
@@ -380,6 +383,11 @@ namespace TPGFEModuleEmulation{
       return true;
     }
 
+    bool isAllZero(std::vector<TPGFEDataformat::TcRawData>& tc) {
+      for(uint32_t itc = 0 ; itc< tc.size(); itc++) if(tc[itc].energy()>0) return false;
+      return true;
+    }
+
 
     TPGFEConfiguration::Configuration& configs;
     TPGFEConfiguration::TPGFEIdPacking pck;
@@ -391,6 +399,12 @@ namespace TPGFEModuleEmulation{
     Emulate(isSim, ievent, moduleId, moddata);
     econtOut=emulOut;
   }
+
+  void ECONTEmulation::EmulateJulTB(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata, TPGFEDataformat::TcModulePacket& econtOut){
+    EmulateJulTB(isSim, ievent, moduleId, moddata);
+    econtOut=emulOut;
+  }
+
   
   void ECONTEmulation::Emulate(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata){
     emulOut.first=moduleId;
@@ -401,6 +415,17 @@ namespace TPGFEModuleEmulation{
       EmulateBC(isSim, ievent, moduleId, moddata);
     else if(outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::STC4B or outputType==TPGFEDataformat::STC16 or TPGFEDataformat::CTC4A or TPGFEDataformat::CTC4B)
       EmulateSTC(isSim, ievent, moduleId, moddata);
+  }
+
+  void ECONTEmulation::EmulateJulTB(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata){
+    emulOut.first=moduleId;
+    emulOut.second.reset();
+    
+    const TPGFEDataformat::Type& outputType = configs.getEconTPara().at(moduleId).getOutType();
+    if(outputType==TPGFEDataformat::BestC)
+      EmulateBC(isSim, ievent, moduleId, moddata);
+    else if(outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::STC4B or outputType==TPGFEDataformat::STC16 or TPGFEDataformat::CTC4A or TPGFEDataformat::CTC4B)
+      EmulateJulSTC(isSim, ievent, moduleId, moddata);
   }
   
   void ECONTEmulation::EmulateSTC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata) {
@@ -536,6 +561,134 @@ namespace TPGFEModuleEmulation{
     }//STC16 select condition
     
   }//Emulate STC
+
+  void ECONTEmulation::EmulateJulSTC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata) {
+    
+    pck.setModId(moduleId);    
+    const std::map<std::tuple<uint32_t,uint32_t,uint32_t>,std::string>& modNameMap = configs.getModIdxToName();
+    const std::map<uint32_t,uint32_t>& refMuxMap = configs.getMuxMapping() ;
+    const std::string& modName = modNameMap.at(std::make_tuple(pck.getDetType(),pck.getSelTC4(),pck.getModule()));
+    uint32_t dropLSB = configs.getEconTPara().at(moduleId).getDropLSB() ;
+    uint32_t nofSTCs = configs.getEconTPara().at(moduleId).getNofSTCs();
+    
+    const TPGFEDataformat::Type& outputType = configs.getEconTPara().at(moduleId).getOutType();
+   
+    if(outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::STC4B or outputType==TPGFEDataformat::CTC4A or outputType==TPGFEDataformat::CTC4B){
+      
+      const std::map<std::string,std::vector<uint32_t>>& modSTClist = (pck.getDetType()==0)?configs.getSiModSTClist():configs.getSciModSTClist();
+      const std::vector<uint32_t>& stclist = modSTClist.at(modName) ;
+      const std::map<std::pair<std::string,uint32_t>,std::vector<uint32_t>>& stcTcMap = (pck.getDetType()==0)?configs.getSiSTCToTC():configs.getSciSTCToTC();
+      uint16_t bx = 0xffff;
+      emulOut.second.reset();
+      for(const auto& istc : stclist){
+	bool isTcTp1 = false;
+	if(istc>=nofSTCs) continue;
+	const std::vector<uint32_t>& tclist = stcTcMap.at(std::make_pair(modName,istc));
+	const TPGFEDataformat::ModuleTcData& mdata = moddata.at(moduleId);
+	bx = (mdata.getBx()==3564) ? 0xF : mdata.getBx() & 0x7 ; 
+	uint64_t decompressedSTC = 0;
+	std::vector<TPGFEDataformat::TcRawData> tcrawdatalist;
+	TPGFEDataformat::TcRawData tcdata;
+	for(const auto& econtc : tclist){
+	  uint32_t hgctc = configs.getEconTPara().at(moduleId).getInputMux(econtc) ;
+	  bool hasFound = false;
+	  uint32_t emultc = 0xffffffff;
+	  for (const auto& it : refMuxMap){
+	    if (it.second == hgctc)  {
+	      hasFound = true;
+	      emultc = it.first;
+	    }
+	  }
+	  if(!hasFound){
+	    std::cerr << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC (moduleid="<<moduleId<<") : Mux not set for TC " << econtc << std::endl;
+	    continue;
+	  }
+	  if(mdata.getTC(emultc).isTcTp1()) isTcTp1 = true;
+	  uint64_t decompressed = DecompressEcont(mdata.getTC(emultc).getCdata(),configs.getEconTPara().at(moduleId).getDensity());
+	  uint64_t decomp64bit =  decompressed * configs.getEconTPara().at(moduleId).getCalibration(econtc) ;
+	  if(isVerbose) std::cout << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC4 (moduleid="<<moduleId<<", TC="<<econtc<<") decompressed: " << decompressed << ", decompressed*calib: " << decomp64bit << std::endl; 
+	  decompressed =  decomp64bit >> 11;
+	  decompressedSTC += decompressed ;
+	  if(isVerbose) std::cout << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC4 (moduleid="<<moduleId<<", TC="<<econtc<<") decompressed*calib>>11: " << decompressed << ", decompressedSTC: " << decompressedSTC << std::endl; 
+	  uint16_t compressed_bc = CompressEcontBc(decompressed, dropLSB);
+	  tcdata.setTriggerCell(TPGFEDataformat::BestC, econtc, compressed_bc, decompressed, mdata.getTC(emultc).isTcTp1()) ;
+	  tcrawdatalist.push_back(tcdata);
+	}
+	batcherOEMSort(tcrawdatalist);
+	uint32_t lMaxId = findLastMax(tcrawdatalist);
+	tcrawdatalist.resize(lMaxId+1);
+	if(isVerbose) std::cout << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC4 (moduleid="<<moduleId<<", STC="<< istc <<") size: " << tcrawdatalist.size() << std::endl;
+	if(isVerbose) for(int i=0;i<tcrawdatalist.size();i++) tcrawdatalist[i].print();
+	std::sort(tcrawdatalist.begin(),tcrawdatalist.end(),TPGFEDataformat::TcRawDataPacket::customGTA);
+	TPGFEDataformat::TcRawData lastMax = isAllZero(tcrawdatalist) ? tcrawdatalist[tcrawdatalist.size()-1] : tcrawdatalist[0] ;
+	if(isVerbose) lastMax.print();
+	uint16_t compressed_energy = (outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::CTC4A) ? CompressEcontStc4E3M(decompressedSTC, dropLSB) : CompressEcontStc5E4M(decompressedSTC);
+	uint64_t raw_E = (outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::CTC4A) ? decompressedSTC>>dropLSB : decompressedSTC ;
+	emulOut.second.setTBM(outputType, bx, 0); 
+	if(outputType==TPGFEDataformat::STC4A or outputType==TPGFEDataformat::STC4B)
+	  emulOut.second.setTcData(outputType, lastMax.address()%4, compressed_energy, raw_E, isTcTp1);
+	else
+	  emulOut.second.setTcData(outputType, istc, compressed_energy, raw_E, isTcTp1);
+	tcrawdatalist.clear();
+      }//stc loop
+      
+    }
+    
+    if(outputType==TPGFEDataformat::STC16){
+      
+      const std::map<std::string,std::vector<uint32_t>>& modSTC16list = (pck.getDetType()==0)?configs.getSiModSTC16list():configs.getSciModSTC16list();
+      const std::vector<uint32_t>& stc16list = modSTC16list.at(modName) ;
+      const std::map<std::pair<std::string,uint32_t>,std::vector<uint32_t>>& stc16TcMap = (pck.getDetType()==0)?configs.getSiSTC16ToTC():configs.getSciSTC16ToTC();
+      uint16_t bx = 0xffff;
+      emulOut.second.reset();
+      for(const auto& istc16 : stc16list){
+	bool isTcTp1 = false;
+	if(istc16>=nofSTCs) continue;
+	const std::vector<uint32_t>& tclist = stc16TcMap.at(std::make_pair(modName,istc16));
+	const TPGFEDataformat::ModuleTcData& mdata = moddata.at(moduleId);
+	bx = (mdata.getBx()==3564) ? 0xF : mdata.getBx() & 0x7 ; 
+	uint64_t decompressedSTC16 = 0;
+	std::vector<TPGFEDataformat::TcRawData> tcrawdatalist;
+	TPGFEDataformat::TcRawData tcdata;
+	for(const auto& econtc : tclist){
+	  uint32_t hgctc = configs.getEconTPara().at(moduleId).getInputMux(econtc) ;
+	  bool hasFound = false;
+	  uint32_t emultc = 0xffffffff;
+	  for (const auto& it : refMuxMap){
+	    if (it.second == hgctc)  {
+	      hasFound = true;
+	      emultc = it.first;
+	    }
+	  }
+	  if(!hasFound){
+	    std::cerr << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC16 (moduleid="<<moduleId<<") : Mux not set for TC " << econtc << std::endl;
+	    continue;
+	  }
+	  if(mdata.getTC(emultc).isTcTp1()) isTcTp1 = true;
+	  uint64_t decompressed = DecompressEcont(mdata.getTC(emultc).getCdata(), configs.getEconTPara().at(moduleId).getDensity());
+	  uint64_t decomp64bit = decompressed * configs.getEconTPara().at(moduleId).getCalibration(econtc) ;
+	  if(isVerbose) std::cout << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC16 (moduleid="<<moduleId<<", TC="<<econtc<<") decompressed: " << decompressed << ", decompressed*calib: " << decomp64bit << std::endl; 
+	  decompressed =  decomp64bit >> 11;
+	  decompressedSTC16 += decompressed ;
+	  if(isVerbose) std::cout << "TPGFEModuleEmulation::ECONTEmulation::EmulateJulSTC16 (moduleid="<<moduleId<<", TC="<<econtc<<") decompressed*calib>>11: " << decompressed << ", decompressedSTC16: " << decompressedSTC16 << std::endl; 
+	  uint16_t compressed_bc = CompressEcontBc(decompressed,dropLSB);
+	  tcdata.setTriggerCell(TPGFEDataformat::BestC, econtc, compressed_bc, decompressed, mdata.getTC(emultc).isTcTp1()) ;
+	  tcrawdatalist.push_back(tcdata);
+	}
+	batcherOEMSort(tcrawdatalist);
+	uint32_t lMaxId = findLastMax(tcrawdatalist);
+	tcrawdatalist.resize(lMaxId+1);
+	std::sort(tcrawdatalist.begin(),tcrawdatalist.end(),TPGFEDataformat::TcRawDataPacket::customGTA);
+	TPGFEDataformat::TcRawData lastMax = isAllZero(tcrawdatalist) ? tcrawdatalist[tcrawdatalist.size()-1] : tcrawdatalist[0] ;
+	uint16_t compressed_energy = CompressEcontStc5E4M(decompressedSTC16);
+	emulOut.second.setTBM(outputType, bx, 0); 
+	emulOut.second.setTcData(outputType, (lastMax.address())%16, compressed_energy, decompressedSTC16, isTcTp1);
+	tcrawdatalist.clear();
+      }//stc16 loop
+    }//STC16 select condition
+    
+  }//Emulate Jul STC
+
   
   void ECONTEmulation::EmulateBC(bool isSim, uint64_t ievent, uint32_t& moduleId, const std::map<uint32_t,TPGFEDataformat::ModuleTcData>& moddata) {
     pck.setModId(moduleId);    

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -60,6 +60,40 @@ namespace l1thgcfirmware {
         }
     }
 
+    void configureTestBeamMappingInfo(){
+      for(unsigned j=0;j<7; j++){ //Module 256, 8448 - BC (high occ for now)
+        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
+        if (j<2){
+          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
+
+        }
+        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
+        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8448][j].size()));
+
+      }
+
+      for(unsigned j=0; j<7;j++){ // Module 768,8960 - STC4A
+        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
+        if(j<5){
+          chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
+        }
+        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
+        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
+      }
+
+
+      for(unsigned j=0; j<3;j++){ // Module 1280,9472 - CTC4A, 
+        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
+        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
+        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
+        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
+      }
+    }
+
     unsigned phiSector() const { return sector120_; }
     uint32_t fpgaID() const { return fpga_id_; }
     unsigned getColBudgetAtIndex(unsigned moduleId, unsigned theColumnIndex) const {

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -86,11 +86,11 @@ namespace l1thgcfirmware {
       }
 
 
-      for(unsigned j=0; j<3;j++){ // Module 1280,9472 - CTC4A, 
+      for(unsigned j=0; j<3;j++){ // Module 1280,9472 - CTC4A in Jul TB 
         chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
         max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
         chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
-        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
+        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
       }
     }
 

--- a/test-beam_Aug24_macros/emul_Jul24.cpp
+++ b/test-beam_Aug24_macros/emul_Jul24.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
   cfgs.readSiChMapping();
   cfgs.readSciChMapping();
   cfgs.loadModIdxToNameMapping();
-  cfgs.loadMuxMapping();
+  cfgs.loadMuxMappingJul24();
   //===============================================================================================================================
   
   //===============================================================================================================================
@@ -586,9 +586,9 @@ int main(int argc, char** argv)
 	  //if(eventCondn or isLargeDiff) modTcdata.second.print();
 	  if(eventCondn or isLargeDiff) TcRawdata.second.print();
 	  if(eventCondn or isLargeDiff) vTC1.print();
-    //up1.setModuleId(moduleId);
+          up1.setModuleId(moduleId);
           if(eventCondn or isLargeDiff) up1.print(); //Stage1 unpacker output results using ECON-T elink data
-    //upemul.setModuleId(moduleId);
+          upemul.setModuleId(moduleId);
 	  if(eventCondn or isLargeDiff) upemul.print();//Stage1 unpacker emulation output
 
     theOutputStreams.resize(0);

--- a/test-beam_Aug24_macros/emul_Jul24.cpp
+++ b/test-beam_Aug24_macros/emul_Jul24.cpp
@@ -57,6 +57,17 @@ l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDa
   return theTCVec;
 }
 
+bool hasDifferentTCs(l1thgcfirmware::HGCalTriggerCellSACollection tcOrig, l1thgcfirmware::HGCalTriggerCellSACollection tcToComp){
+   if(tcOrig.size()!=tcToComp.size()) return true;
+   for(unsigned i = 0; i<tcOrig.size(); i++){ 
+       if (tcOrig.at(i).energy()!=tcToComp.at(i).energy() || tcOrig.at(i).phi()!=tcToComp.at(i).phi() || tcOrig.at(i).channel()!=tcToComp.at(i).channel() || tcOrig.at(i).frame()!=tcToComp.at(i).frame() || tcOrig.at(i).column()!=tcToComp.at(i).column()){
+	       return true;
+       }
+   }
+   return false;
+}
+
+
 
 int main(int argc, char** argv)
 {
@@ -488,7 +499,7 @@ int main(int argc, char** argv)
 	  //================================================
 	  //ECONT emulation for a given module
 	  //================================================
-	  econtEmul.Emulate(isSim, event, moduleId, moddata);
+	  econtEmul.EmulateJulTB(isSim, event, moduleId, moddata);
 	  TPGFEDataformat::TcModulePacket& TcRawdata = econtEmul.accessTcRawDataPacket();
 	  //================================================
 	  if(TcRawdata.second.type()==TPGFEDataformat::BestC) TcRawdata.second.sortCh();
@@ -610,14 +621,18 @@ int main(int argc, char** argv)
     unsigned error_code = theAlgo_.run(theTCsFromOS, theConfiguration_, tcs_out_SA);
     unsigned error_code_emul = theAlgo_.run(theTCsFromOS_emul, theConfiguration_, tcs_out_emul_SA);
 
-    std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from ECON-T elink input"<<std::endl;
-    for (auto& tcobj : tcs_out_SA){
-      std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
-    }
+    bool diffTCs=hasDifferentTCs(tcs_out_SA,tcs_out_emul_SA);
 
-    std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from emulator input"<<std::endl;
-    for (auto& tcobj : tcs_out_emul_SA){
-      std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
+    if(eventCondn or diffTCs){
+      std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from ECON-T elink input"<<std::endl;
+      for (auto& tcobj : tcs_out_SA){
+        std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
+      }
+
+      std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from emulator input"<<std::endl;
+      for (auto& tcobj : tcs_out_emul_SA){
+        std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
+      }
     }
 
 
@@ -967,3 +982,4 @@ void FillHistogram(bool matchFound, TDirectory*& dir_diff, uint32_t relayNumber,
   }//if matched
   
 }
+


### PR DESCRIPTION
This PR adds the TC processor emulator as a test step into `emul_Jul24`. For now the code checks if the output from running this code on the emulated Stage1UnpackerOutput and from running the TC processor on the raw data passed through the unpacker is the same; if not it prints the contents of the trigger cells.

Example log attached for those who are interested [jul24_tcprocemul_notrim.log](https://github.com/user-attachments/files/17102428/jul24_tcprocemul_notrim.log)

As you can see in the log, some of the TC processor outputs do not match, but this is due to a difference in the energy that's already present in the original input data, and not something introduced by the TC processor. Everything else looks good.

The above is run with the command from the README, so w/o trimming. If I turn trimming on, the raw data and the emulated equivalent don't match at all, I'm not sure if that is expected. 

One thing to note is that https://github.com/indra-ehep/hgcal-tpg-fe/commit/e71914dce074845239e428c546975cfc5e248186 introduced changes that 'break' `emul_Jul24` (in the sense that addresses between raw and emulated no longer matched). For the purpose of the comparison done here, I introduced some 'Jul24'-specific functions in `TPGFEModuleEmulation.hh` and `TPGFEConfiguration.hh`. The solution is not the most elegant, but this was the fastest way to remove that code again in case we don't need this anymore. However, if desired I can also just turn this into an optional flag for the functions that are now somewhat duplicated - this depends on how much analysis/checks on the old testbeam data is still foreseen. Either way, if we have scripts that can be used to analyze the older data, I think it's best if they return sensible results (alternatively, but maybe not as nice, a version of the repo could be tagged for people who need to use a particular macro, if no developments of that macro are planned anymore)
