### PR TITLE
Change of ECONT mode

### DIFF
--- a/inc/TPGFEDataformat.hh
+++ b/inc/TPGFEDataformat.hh
@@ -45,12 +45,12 @@ namespace TPGFEDataformat{
       return _data&0xfff;
     }
 
-    void setAdc(uint16_t a, uint16_t tctp=0x0) {
+    void setAdc(uint16_t a, uint16_t tctp) {
       assert(a<0x400 and tctp<0x4);
       _data=tctp<<12|a;
     }
     
-    void setTot(uint16_t a, uint16_t tctp=0x3) {
+    void setTot(uint16_t a, uint16_t tctp) {
       assert(a<0x1000 and tctp<0x4);
       _data=tctp<<12|a|0x8000;
     }
@@ -58,7 +58,10 @@ namespace TPGFEDataformat{
     void print() const {
       std::cout << "HalfHgcrocChannelData(" << this << ")::print()" << std::endl;
 
-      std::cout << std::dec << ::std::setfill(' ') << ", "
+      std::cout << std::dec << ::std::setfill(' ') 
+		<<" data: 0x" << std::hex << ::std::setfill('0')
+		<< std::setw(4) << _data 
+		<< std::dec << ::std::setfill(' ') << ", "
 		<< "TcTp: " << getTcTp() << ", "
 		<< (isTot()?"TOT = ":"ADC = ") << std::setw(4)
 		<< (isTot()?getTot():getAdc())
@@ -98,9 +101,13 @@ namespace TPGFEDataformat{
     bool hasTcTp2() const { return hasTcTp(2); }
     bool hasTcTp3() const { return hasTOT(); }
     
-    bool hasTcTp(uint16_t tctpval = 1) const {
-      for(unsigned i(0);i<=NumberOfChannels;i++)
-	if(_data[i].getTcTp()==tctpval) return true;
+    bool hasTcTp(uint16_t tctpval) const {
+      for(unsigned i(0);i<NumberOfChannels;i++)
+	if(_data[i].getTcTp()==tctpval) {
+	  std::cout << "ich : " << i ; 
+	  _data[i].print();
+	  return true;
+	}
       return false;
     }
 
@@ -164,7 +171,7 @@ namespace TPGFEDataformat{
     TcRawData() : _data(0), _rawE(0), _istctp1(false), _istctp2(false), _istctp3(false) {
     }
     
-    TcRawData(TPGFEDataformat::Type t, uint8_t a, uint16_t e, uint64_t rawE = 0, bool istctp1 = false, bool istctp2 = false, bool istctp3 = false) {
+    TcRawData(TPGFEDataformat::Type t, uint8_t a, uint16_t e, uint64_t rawE = 0, bool istctp1  = false, bool istctp2  = false, bool istctp3 = false) {
       setTriggerCell(t,a,e, rawE, istctp1, istctp2, istctp3);
     }
     
@@ -424,7 +431,7 @@ namespace TPGFEDataformat{
     void setModuleSum(uint8_t e, uint64_t upe) { _ms = e; _rawEms = upe;}
     void setBX(uint8_t bx) { _bx = bx;}
     std::vector<TPGFEDataformat::TcRawData>& setTcData() {return _tcdata;}
-    void setTcData(TPGFEDataformat::Type t, uint8_t a, uint16_t e, uint64_t upe=0, bool isTcTp1=false, bool isTcTp2=false, bool isTcTp3=false) {
+    void setTcData(TPGFEDataformat::Type t, uint8_t a, uint16_t e, uint64_t upe, bool isTcTp1, bool isTcTp2, bool isTcTp3) {
       TPGFEDataformat::TcRawData tc;
       tc.setTriggerCell(t, a, e, upe, isTcTp1, isTcTp2, isTcTp3);
       _tcdata.push_back(tc);

--- a/inc/TPGFEDataformat.hh
+++ b/inc/TPGFEDataformat.hh
@@ -65,6 +65,8 @@ namespace TPGFEDataformat{
 		<< "TcTp: " << getTcTp() << ", "
 		<< (isTot()?"TOT = ":"ADC = ") << std::setw(4)
 		<< (isTot()?getTot():getAdc())
+		// << "ADC = " << std::setw(4) << getAdc() <<", "
+		// << ((getTcTp()!=0) ? Form("TOT = %u",getTot()) : "")
 		<< std::endl;
 
     }
@@ -104,8 +106,8 @@ namespace TPGFEDataformat{
     bool hasTcTp(uint16_t tctpval) const {
       for(unsigned i(0);i<NumberOfChannels;i++)
 	if(_data[i].getTcTp()==tctpval) {
-	  std::cout << "ich : " << i ; 
-	  _data[i].print();
+	  // std::cout << "TOT/TOA noted for ich : " << i << std::endl; 
+	  // _data[i].print();
 	  return true;
 	}
       return false;
@@ -138,6 +140,8 @@ namespace TPGFEDataformat{
 		  << " TcTp: " << _data[i].getTcTp() << ", "
 		  << (_data[i].isTot()?"TOT = ":"ADC = ") << std::setw(4)
 		  << (_data[i].isTot()?_data[i].getTot():_data[i].getAdc())
+		  // << "ADC = " << std::setw(4) << _data[i].getAdc() <<", "
+		  // << ((_data[i].getTcTp()!=0) ? Form("TOT = %u",_data[i].getTot()) : "")
 		  << std::endl;
       }    
     }

--- a/inc/TPGFEReaderSep2024.hh
+++ b/inc/TPGFEReaderSep2024.hh
@@ -320,25 +320,29 @@ namespace TPGFEReader{
 	    if(seqToRocpin.find(std::make_pair(modName,std::make_tuple(rocn,half,seqM)))!=seqToRocpin.end()){
 	      uint32_t rocpin = seqToRocpin.at(std::make_pair(modName,std::make_tuple(rocn,half,seqM))) ;
 	      ch = rocpin%36 ; //36 for halfroc
-	      if(trigflagM>=0x2)
+	      if(trigflagM>=0x2){
 		chdata[ch].setTot(uint16_t(totM),uint16_t(trigflagM));
-	      else if(trigflagM==0)
+		//chdata[ch].setAdc(uint16_t(adcmM),0);
+	      }else if(trigflagM==0)
 		chdata[ch].setAdc(uint16_t(adcM),uint16_t(trigflagM));
-	      else if(trigflagM==0x1)
+	      else if(trigflagM==0x1){
 		chdata[ch].setAdc(0,uint16_t(trigflagM)); //uint16_t(adcM)
-	      else
+		//chdata[ch].setTot(uint16_t(toaM),uint16_t(trigflagM));
+	      }else
 		chdata[ch].setZero();
 	    }
 	    if(seqToRocpin.find(std::make_pair(modName,std::make_tuple(rocn,half,seqL)))!=seqToRocpin.end()){
 	      uint32_t rocpin = seqToRocpin.at(std::make_pair(modName,std::make_tuple(rocn,half,seqL))) ;
 	      ch = rocpin%36 ; //36 for halfroc
-	      if(trigflagL>=0x2)
+	      if(trigflagL>=0x2){
 		chdata[ch].setTot(uint16_t(totL),uint16_t(trigflagL));
-	      else if(trigflagL==0)
+		//chdata[ch].setAdc(uint16_t(adcmL),0);
+	      }else if(trigflagL==0)
 		chdata[ch].setAdc(uint16_t(adcL),uint16_t(trigflagL));
-	      else if(trigflagL==0x1)
+	      else if(trigflagL==0x1){
 		chdata[ch].setAdc(0,uint16_t(trigflagL)); //uint16_t(adcL)
-	      else
+		//chdata[ch].setTot(uint16_t(toaL),uint16_t(trigflagL));
+	      }else
 		chdata[ch].setZero();
 	    }
 	    index++;
@@ -478,6 +482,7 @@ namespace TPGFEReader{
 		nofecons++;
 	      }
 	    }
+	    if ((nEvents < nShowEvents) or (scanMode and boe->eventId()==inspectEvent)) std::cout << "icapblk: " << icapblk << ", nofecons: " << nofecons << std::endl;
 	    //assert(nofecons!=0);
 	    if(nofecons!=3) {
 	      isThreeEcons = false;
@@ -505,17 +510,25 @@ namespace TPGFEReader{
 	      zeroloc[iecond] = (econsize-1)/2 + (econpos+1) ; //(econ0pos+1): +1 to start from first eRx header
 	      zeropos_lst[icapblk].push_back(zeroloc[iecond]);
 	      next_econd_pos = zeroloc[iecond]+1 ;
+	      if ((nEvents < nShowEvents) or (scanMode and boe->eventId()==inspectEvent)){
+		std::cout << "icapblk: " << icapblk << ", iecond: " << iecond << ", econh0: " << econh0 << ", econh1: " << econh1
+			  <<", econsize: " << econsize
+			  << ", zeroloc[iecond]: " << zeroloc[iecond] << std::endl;
+	      }
 	    }
 	    capturepos = zeroloc[nofecons-1] + 1 ;
 	    icapblk++;
 	  }//find the block positions
 	  if ((nEvents < nShowEvents) or (scanMode and boe->eventId()==inspectEvent)){
+	    std::cout<< " icapblk: " << icapblk << std::endl;
 	    std::cout<< " econheaderpos_lst.size(): " << econheaderpos_lst.size() << std::endl;
+	    std::cout<< " isThreeEcons: "<< isThreeEcons << ", isallPassthrough: "<< isallPassthrough << ", isValideRxSize: " << isValideRxSize << std::endl;
 	    for (const auto&  econhpos : econheaderpos_lst)
 	      for(int iecond = 0 ; iecond < econheaderpos_lst[econhpos.first].size() ; iecond++)
 		std::cout<<"icapblk: "<<econhpos.first<<" zero position for econ " << iecond << ", "<<zeropos_lst[econhpos.first].at(iecond)<<std::endl;
 	  }
-	  if(isThreeEcons and isallPassthrough and isValideRxSize){
+	  //if(isThreeEcons and isallPassthrough and isValideRxSize){
+	  if(isallPassthrough and isValideRxSize){
 	    getModuleData(nEvents, hrocarray, events);
 	    events.push_back(boe->eventId());
 	  }

--- a/test-beam_Sep24_macros/emul_Sep24.cpp
+++ b/test-beam_Sep24_macros/emul_Sep24.cpp
@@ -235,14 +235,26 @@ int main(int argc, char** argv)
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(3);
       econTPar[it.first].setSTCType(3);
+      if(relayNumber>=1727111828){ //1727211141
+	econTPar[it.first].setNElinks(2);
+	econTPar[it.first].setSTCType(1);
+      }
     }else if (it.first==lp1_stc4a1){
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(3);
+      if(relayNumber>=1727111828){ //1727211141
+	econTPar[it.first].setNElinks(2);
+	econTPar[it.first].setSTCType(1);
+      }
     }else if (it.first==lp1_stc4a2){
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(3);
+      if(relayNumber>=1727111828){ //1727211141
+	econTPar[it.first].setNElinks(2);
+	econTPar[it.first].setSTCType(1);
+      }
     }
     std::cout << "Modtype " << it.first
 	      << ", getOuttype: " << econTPar[it.first].getOutType()
@@ -268,8 +280,8 @@ int main(int argc, char** argv)
   //===============================================================================================================================
   TPGFEReader::ECONDReader econDReader(cfgs);
   econDReader.setTotUp(0);
-  //econDReader.checkEvent(1);
-  //econDReader.showFirstEvents(10);
+  econDReader.checkEvent(1);
+  // econDReader.showFirstEvents(10);
   //===============================================================================================================================
   //Set and Initialize the Emulator
   //===============================================================================================================================
@@ -280,14 +292,15 @@ int main(int argc, char** argv)
   //===============================================================================================================================
   //Set refernce eventlist
   //===============================================================================================================================
-  // /*Nonzero diff events*/ uint64_t refEvt[6] = {66235, 471496, 1763515, 1968826, 2245408, 2390648};
-  // /*Unexpected TC in Data in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
-  // /*Unexpected TC in Emul in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
-  /*Difference in elink and Stage1 output in event*/ uint64_t refEvt[21] = {66235, 151731, 471496, 633065, 873524, 1366513, 1589006, 1623036, 1763515, 1968826, 1984675, 2000515, 2091972, 2165732, 2245408, 2250959, 2259447, 2264639, 2335560, 2390648, 2489154};
+  /*TcTp2 events */ uint64_t refEvt[50] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1809836, 1829961, 1871023, 1932945, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
+  // /*Nonzero diff events*/ uint64_t refEvt[6] = {66235, 471496, 1763515, 1968826, 2245408, 2390648, };
+  // /*Unexpect TC in Data in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946, };
+  // /*Unexpect TC in Emul in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946, };
+  // /*Difference in elink and Stage1 output in event*/ uint64_t refEvt[21] = {66235, 151731, 471496, 633065, 873524, 1366513, 1589006, 1623036, 1763515, 1968826, 1984675, 2000515, 2091972, 2165732, 2245408, 2250959, 2259447, 2264639, 2335560, 2390648, 2489154, };
+
   std::vector<uint64_t> refEvents;
-  //for(int ievent=0;ievent<25702;ievent++) refEvents.push_back(refEvt[ievent]);
   //for(int ievent=0;ievent<1020;ievent++) refEvents.push_back(refEvt[ievent]);
-  for(int ievent=0;ievent<21;ievent++) refEvents.push_back(refEvt[ievent]);
+  for(int ievent=0;ievent<50;ievent++) refEvents.push_back(refEvt[ievent]);
   refEvents.resize(0);
   //===============================================================================================================================
   
@@ -309,15 +322,11 @@ int main(int argc, char** argv)
   TcTp3Events.clear();
   
   uint64_t minEventDAQ, maxEventDAQ;  
-  //const long double maxEvent = 882454  ; 
-  //const long double maxEvent = 1038510 ;
-  //const long double maxEvent = 6377139 ; 
-  //const long double maxEvent = 1138510 ;
   //const long double maxEvent = 1000000 ;
-  const long double maxEvent = 2557415 ;
-  long double nloopEvent =  100000;
-  // const long double maxEvent = 100000  ; //1722870998:24628, 1722871979:31599
-  // long double nloopEvent = 100000 ;
+  // const long double maxEvent = 2557415 ;
+  // long double nloopEvent =  100000;
+  const long double maxEvent = 1000  ; //1722870998:24628, 1722871979:31599
+  long double nloopEvent = 1000 ;
   int nloop = TMath::CeilNint(maxEvent/nloopEvent) ;
   if(refEvents.size()>0) nloop = 1;
   std::cout<<"nloop: "<<nloop<<std::endl;
@@ -512,9 +521,9 @@ int main(int argc, char** argv)
 	      if(eventCondn and iecond==0 and ilink==0) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, 6, el, vTC1);
 	      if(eventCondn and iecond==1 and ilink==0) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, 4, el, vTC1);
 	      if(eventCondn and iecond==2 and ilink==0) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, 4, el, vTC1);
-	      if(eventCondn and iecond==0 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 10, el, vTC1);
-	      if(eventCondn and iecond==1 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 6, el, vTC1);
-	      if(eventCondn and iecond==2 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 5, el, vTC1);
+	      if(eventCondn and iecond==0 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, 3, el, vTC1);
+	      if(eventCondn and iecond==1 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, 3, el, vTC1);
+	      if(eventCondn and iecond==2 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, 3, el, vTC1);
 	      if(eventCondn) TPGStage1Emulation::Stage1IO::convertTcRawDataToUnpackerOutputStreamPair(bx_2, vTC1, up1);
 	      if(eventCondn) vTC1.print();
 	      // if(eventCondn) up1.print();

--- a/test-beam_Sep24_macros/emul_Sep24.cpp
+++ b/test-beam_Sep24_macros/emul_Sep24.cpp
@@ -280,21 +280,14 @@ int main(int argc, char** argv)
   //===============================================================================================================================
   //Set refernce eventlist
   //===============================================================================================================================
-  //uint64_t refEvt[] = {1560, 2232, 2584, 2968, 3992, 4344, 5048, 5848, 6168, 8248, 9976};
-  //uint64_t refEvt[] = {1, 2, 3, 4, 5};
-  //uint64_t refEvt[30] = {3128, 9954, 16733, 19162, 33927, 34190, 37363, 37827, 40369, 45842, 46118, 46373, 46419, 46506, 52079, 53856, 58912, 60802, 62177, 62275, 64008, 65645, 67282, 77309, 84325, 86764, 87628, 91094, 97064, 99445};
-  
-  //uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
-
-  //uint64_t refEvt[20] = {1, 2, 3, 66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213};
-
-  //uint64_t refEvt[20] = {1, 2, 3, 66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213};
-  //uint64_t refEvt[6] = {66235, 471496, 1763515, 1968826, 2245408, 2390648};
-  int64_t refEvt[45] = {66235, 471496, 1763515, 1968826, 2245408, 2390648, 127532, 145302, 194816, 260756, 269698, 383736, 391481, 397781, 534349, 605680, 613325, 694404, 873524, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1769677, 1871023, 1967257, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2259447, 2462559, 2514946};
+  // /*Nonzero diff events*/ uint64_t refEvt[6] = {66235, 471496, 1763515, 1968826, 2245408, 2390648};
+  // /*Unexpected TC in Data in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
+  // /*Unexpected TC in Emul in event*/ uint64_t refEvt[48] = {66235, 127532, 145302, 151731, 194816, 260756, 269698, 383736, 391481, 397781, 471496, 534349, 605680, 613325, 694404, 873524, 919213, 1085378, 1124673, 1164106, 1222670, 1247896, 1278016, 1322821, 1453497, 1486909, 1533310, 1623036, 1661345, 1763515, 1769677, 1829961, 1871023, 1967257, 1968826, 1981516, 1984675, 2043998, 2060794, 2068723, 2165732, 2172380, 2237980, 2245408, 2259447, 2390648, 2462559, 2514946};
+  /*Difference in elink and Stage1 output in event*/ uint64_t refEvt[21] = {66235, 151731, 471496, 633065, 873524, 1366513, 1589006, 1623036, 1763515, 1968826, 1984675, 2000515, 2091972, 2165732, 2245408, 2250959, 2259447, 2264639, 2335560, 2390648, 2489154};
   std::vector<uint64_t> refEvents;
   //for(int ievent=0;ievent<25702;ievent++) refEvents.push_back(refEvt[ievent]);
   //for(int ievent=0;ievent<1020;ievent++) refEvents.push_back(refEvt[ievent]);
-  for(int ievent=0;ievent<45;ievent++) refEvents.push_back(refEvt[ievent]);
+  for(int ievent=0;ievent<21;ievent++) refEvents.push_back(refEvt[ievent]);
   refEvents.resize(0);
   //===============================================================================================================================
   
@@ -307,6 +300,13 @@ int main(int argc, char** argv)
   std::vector<uint64_t> unExDataTC;
   std::vector<uint64_t> unExEmulTC;
   std::vector<uint64_t> elStg1Event;
+  std::vector<uint64_t> TcTp1Events;
+  std::vector<uint64_t> TcTp2Events;
+  std::vector<uint64_t> TcTp3Events;
+
+  TcTp1Events.clear();
+  TcTp2Events.clear();
+  TcTp3Events.clear();
   
   uint64_t minEventDAQ, maxEventDAQ;  
   //const long double maxEvent = 882454  ; 
@@ -316,8 +316,8 @@ int main(int argc, char** argv)
   //const long double maxEvent = 1000000 ;
   const long double maxEvent = 2557415 ;
   long double nloopEvent =  100000;
-  // const long double maxEvent = 100  ; //1722870998:24628, 1722871979:31599
-  // long double nloopEvent = 100 ;
+  // const long double maxEvent = 100000  ; //1722870998:24628, 1722871979:31599
+  // long double nloopEvent = 100000 ;
   int nloop = TMath::CeilNint(maxEvent/nloopEvent) ;
   if(refEvents.size()>0) nloop = 1;
   std::cout<<"nloop: "<<nloop<<std::endl;
@@ -353,23 +353,22 @@ int main(int argc, char** argv)
     // }
     // continue;
     
-    //std::vector<uint64_t> totEvents;
     for(uint64_t ievt = 0 ; ievt < eventList.size(); ievt++ ){
       uint64_t ievent = eventList[ievt] ;
       if(econtarray.at(ievent).size()!=6 or hrocarray.at(ievent).size()!=36) continue;
       std::vector<std::pair<uint32_t,TPGFEDataformat::HalfHgcrocData>> datalist = hrocarray[ievent] ;
       if(ievt<100) std::cout << "ROC ievent: "<< ievent<< ", datalist size: "<< datalist.size() << std::endl;
-      bool hasTOT = false;
       for(const auto& hrocit : datalist){
 	const TPGFEDataformat::HalfHgcrocData& hrocdata = hrocit.second ;
 	//if(testmodid==pck.getModIdFromRocId(uint32_t(hrocit.first))){
 	//if(event<100 and (iecond==1 and ilink==0)){
 	if(ievt<100) std::cout << "ievent: "<< ievent<< "\t data for modid : "<< pck.getModIdFromRocId(uint32_t(hrocit.first)) << ",\t half-roc_id: "<< hrocit.first <<  std::endl;
 	if(ievt<100) hrocdata.print();
-	if(hrocdata.hasTOT()) hasTOT = true;
-	//}
+	if(hrocdata.hasTcTp(1) and (std::find(TcTp1Events.begin(),TcTp1Events.end(),ievent) == TcTp1Events.end())) TcTp1Events.push_back(ievent);
+	if(hrocdata.hasTcTp(2) and (std::find(TcTp2Events.begin(),TcTp2Events.end(),ievent) == TcTp2Events.end())) TcTp2Events.push_back(ievent);
+	if(hrocdata.hasTcTp(3) and (std::find(TcTp3Events.begin(),TcTp3Events.end(),ievent) == TcTp3Events.end())) TcTp3Events.push_back(ievent);
       }
-      //if(hasTOT) totEvents.push_back(ievent);
+
     }
     
     //===============================================================================================================================
@@ -396,7 +395,7 @@ int main(int argc, char** argv)
 
       //bool eventCondn = (event<1000 or event==1560 or event==2232 or event==2584 or event==2968 or event==3992);
       //bool eventCondn = (event<1000);
-      bool eventCondn = (ievt<10);
+      bool eventCondn = (refEvents.size()==0) ? (ievt<10) : (ievt<refEvents.size());
       if( eventCondn or event%100000==0)
 	std::cout<<std::endl<<std::endl<<"=========================================================================="<<std::endl<<"Processing event: " << event <<std::endl<<std::endl<<std::endl;
       
@@ -482,6 +481,11 @@ int main(int argc, char** argv)
 	  uint32_t *elinkemul = new uint32_t[econTPar[moduleId].getNElinks()];
 	  TPGFEModuleEmulation::ECONTEmulation::convertToElinkData(emul_bx_4b, TcRawdata.second, elinkemul);
 	  
+	  // if(TcRawdata.second.isTcTp1() and (std::find(TcTp1Events.begin(),TcTp1Events.end(),event) == TcTp1Events.end())) TcTp1Events.push_back(event);
+	  // if(TcRawdata.second.isTcTp2() and (std::find(TcTp2Events.begin(),TcTp2Events.end(),event) == TcTp2Events.end())) TcTp2Events.push_back(event);
+	  // if(TcRawdata.second.isTcTp3() and (std::find(TcTp3Events.begin(),TcTp3Events.end(),event) == TcTp3Events.end())) TcTp3Events.push_back(event);
+
+	  
 	  std::vector<std::pair<uint32_t,TPGBEDataformat::Trig24Data>> econtdata =  econtarray[event];
 	  
 	  TPGBEDataformat::UnpackerOutputStreamPair upemul,up1;
@@ -512,8 +516,8 @@ int main(int argc, char** argv)
 	      if(eventCondn and iecond==1 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 6, el, vTC1);
 	      if(eventCondn and iecond==2 and ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 5, el, vTC1);
 	      if(eventCondn) TPGStage1Emulation::Stage1IO::convertTcRawDataToUnpackerOutputStreamPair(bx_2, vTC1, up1);
-	      //if(eventCondn) vTC1.print();
-	      //if(eventCondn and iecond==0 and ilink==1) up1.print();
+	      if(eventCondn) vTC1.print();
+	      // if(eventCondn) up1.print();
 	    }//bx loop
 	    //if(eventCondn) trdata.print();
 	    if(hasMatched) break;
@@ -587,8 +591,9 @@ int main(int argc, char** argv)
 	  //if(printCondn) modTcdata.second.print();
 	  if(printCondn) TcRawdata.second.print();
 	  if(printCondn) vTC1.print();
-          //if(printCondn) up1.print();
-	  // if(printCondn) upemul.print();
+          if(printCondn) up1.print();
+	  if(printCondn) upemul.print();
+	  if(printCondn) trdata.print();
 	  // 
 	  for(uint32_t iel=0;iel<econTPar[moduleId].getNElinks();iel++){
 	    if(printCondn) std::cout<<"Elink emul : 0x" << std::hex << std::setfill('0') << std::setw(8) << elinkemul[iel] << std::dec ;
@@ -616,6 +621,18 @@ int main(int argc, char** argv)
     }//event loop
   }//ieloop
   //===============================================================================================================================
+  if(TcTp1Events.size()>0) std::cerr<< "/*TcTp1 events */ uint64_t refEvt["<< TcTp1Events.size() <<"] = {";
+  for(const uint64_t& totEvt : TcTp1Events) std::cerr<<totEvt << ", ";
+  if(TcTp1Events.size()>0) std::cerr<< "};" << std::endl;
+
+  if(TcTp2Events.size()>0) std::cerr<< "/*TcTp2 events */ uint64_t refEvt["<< TcTp2Events.size() <<"] = {";
+  for(const uint64_t& totEvt : TcTp2Events) std::cerr<<totEvt << ", ";
+  if(TcTp2Events.size()>0) std::cerr<< "};" << std::endl;
+
+  if(TcTp3Events.size()>0) std::cerr<< "/*TcTp3 events */ uint64_t refEvt["<< TcTp3Events.size() <<"] = {";
+  for(const uint64_t& totEvt : TcTp3Events) std::cerr<<totEvt << ", ";
+  if(TcTp3Events.size()>0) std::cerr<< "};" << std::endl;
+
   if(nonZeroEvents.size()>0) std::cerr<< "/*Nonzero diff events*/ uint64_t refEvt["<< nonZeroEvents.size() <<"] = {";
   for(const uint64_t& totEvt : nonZeroEvents) std::cerr<<totEvt << ", ";
   if(nonZeroEvents.size()>0) std::cerr<< "};" << std::endl;
@@ -1065,7 +1082,15 @@ void FillHistogram(bool matchFound, bool isLargeDiff, TDirectory*& dir_diff, uin
 	else
 	  ((TH1D *) list->FindObject("hUWord_1"))->Fill( diff );
 	if(iw>0) ((TH1D *) list->FindObject( Form("hUnpkWordDiff_%d_%d_%d_%d",imodeloc,ilp,imdl,iw-1) ))->Fill( diff );
-	if(iw>0 and diff!=0 and std::find(elStg1Event.begin(),elStg1Event.end(),event) == elStg1Event.end()) elStg1Event.push_back(event);
+	if(iw>0 and diff!=0 and std::find(elStg1Event.begin(),elStg1Event.end(),event) == elStg1Event.end()) {
+	  elStg1Event.push_back(event);
+	  std::cout << "Error:: iw: " << iw << ", unpkMsTc[iw]: 0x"
+		    << std::hex << std::setfill('0') << std::setw(4) << unpkMsTc[iw] << ", word: 0x" << unpkWords[iw] 
+		    << std::dec << std::setfill(' ')
+		    << ", diff: " << diff
+		    <<", TC energy : " << tcdata.getTcData().at(iw-1).energy() <<", TC address : " << tcdata.getTcData().at(iw-1).address()
+		    << std::endl;
+	}
       }
     }else if (tcdata.size()>7 and tcdata.size()<=14) {
       int diff = 99;
@@ -1087,7 +1112,15 @@ void FillHistogram(bool matchFound, bool isLargeDiff, TDirectory*& dir_diff, uin
 	else
 	  ((TH1D *) list->FindObject("hUWord_1"))->Fill( diff );
 	if(iw>0) ((TH1D *) list->FindObject( Form("hUnpkWordDiff_%d_%d_%d_%d",imodeloc,ilp,imdl,iw-1) ))->Fill( diff );
-	if(iw>0 and diff!=0 and std::find(elStg1Event.begin(),elStg1Event.end(),event) == elStg1Event.end()) elStg1Event.push_back(event);
+	if(iw>0 and diff!=0 and std::find(elStg1Event.begin(),elStg1Event.end(),event) == elStg1Event.end()) {
+	  elStg1Event.push_back(event);
+	  std::cout << "Error1:: iw: " << iw << ", unpkMsTc[iw]: 0x"
+		    << std::hex << std::setfill('0') << std::setw(4) << unpkMsTc[iw] << ", word: 0x" << word
+		    << std::dec << std::setfill(' ')
+		    << ", diff: " << diff
+		    <<", TC energy : " << tcdata.getTcData().at(iw-1).energy() <<", TC address : " << tcdata.getTcData().at(iw-1).address()
+		    << std::endl;
+	}
       }
       ;
     }


### PR DESCRIPTION
Changes
1) Adapting the change of ECON-T mode for layer2 after the inclusion of third layer.
2) Reading DAQ data for first two layers after the inclusion of additional capture for third layer. 