### PR TITLE
Add comparison of TC processor data in TB and emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ emul_Jul24.exe: test-beam_Aug24_macros/emul_Jul24.cpp inc/*.*  TPGFEEmulation/*.
 	g++ $(LDFLAGS) -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc $(CPPFLAGS) test-beam_Aug24_macros/emul_Jul24.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_Jul24.exe -lm
 
 tpgdata_3T_tcproc.exe: test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
-	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp  -l yaml-cpp `root-config --libs --cflags` -o tpgdata_3T_tcproc.exe -lm
+	g++ $(LDFLAGS) -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc $(CPPFLAGS) test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp  -l yaml-cpp `root-config --libs --cflags` -o tpgdata_3T_tcproc.exe -lm
 
 tpgdata_3T_fe.exe: test-beam_Sep24_macros/tpgdata_3T_fe.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep24_macros/tpgdata_3T_fe.cpp  -l yaml-cpp `root-config --libs --cflags` -o tpgdata_3T_fe.exe -lm

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -31,139 +31,132 @@ namespace l1thgcfirmware {
       }
     }*/
 
-    void configureMappingInfo(){
-        for(unsigned iModGroup=0; iModGroup<58;iModGroup++){
-            for(unsigned j=0; j<4; j++){//BC low (mod 1) - 4 bins, 1TC/bin
-                chn_frame_slots_per_mod_and_col_[1+iModGroup*5][j].push_back(std::make_pair(0,0));
-                max_tcs_per_module_and_column_[1+iModGroup*5].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1][j].size()));
-            }
-            for(unsigned j=0; j<7; j++){//BC high (mod 0) - 7 bins, 2 TC/bin bin 1-2; 1TC/bin rest
-                chn_frame_slots_per_mod_and_col_[iModGroup*5][j].push_back(std::make_pair(0,0));
-                if(j<2){
-                    chn_frame_slots_per_mod_and_col_[iModGroup*5][j].push_back(std::make_pair(0,0));
-                }
-                max_tcs_per_module_and_column_[iModGroup*5].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[0][j].size()));
-            }
-            for(unsigned j=0; j<3; j++){//STC16 (mod 3-4) - 3 bins, 1TC/bin
-                for(unsigned i=3; i<5; i++){
-                    chn_frame_slots_per_mod_and_col_[i+iModGroup*5][j].push_back(std::make_pair(0,0));
-                    max_tcs_per_module_and_column_[i+iModGroup*5].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[i][j].size()));
-                }
-            }
-            for(unsigned j=0; j <7; j++){//STC4 (mod 2) - 7 bins, 2TC/bin bin 1-5; 1TC/bin rest
-                chn_frame_slots_per_mod_and_col_[2+iModGroup*5][j].push_back(std::make_pair(0,0));
-                if(j<5){
-                    chn_frame_slots_per_mod_and_col_[2+iModGroup*5][j].push_back(std::make_pair(0,0));
-                }
-                max_tcs_per_module_and_column_[2+iModGroup*5].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[2][j].size()));
-            }
+    void configureMappingInfo() {
+      for (unsigned iModGroup = 0; iModGroup < 58; iModGroup++) {
+        for (unsigned j = 0; j < 4; j++) {  //BC low (mod 1) - 4 bins, 1TC/bin
+          chn_frame_slots_per_mod_and_col_[1 + iModGroup * 5][j].push_back(std::make_pair(0, 0));
+          max_tcs_per_module_and_column_[1 + iModGroup * 5].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[1][j].size()));
         }
-    }
-
-    void configureTestBeamMappingInfo(){
-      for(unsigned j=0;j<7; j++){ //Module 256, 8448 - BC (high occ for now)
-        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
-        if (j<2){
-          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
-
+        for (unsigned j = 0; j < 7; j++) {  //BC high (mod 0) - 7 bins, 2 TC/bin bin 1-2; 1TC/bin rest
+          chn_frame_slots_per_mod_and_col_[iModGroup * 5][j].push_back(std::make_pair(0, 0));
+          if (j < 2) {
+            chn_frame_slots_per_mod_and_col_[iModGroup * 5][j].push_back(std::make_pair(0, 0));
+          }
+          max_tcs_per_module_and_column_[iModGroup * 5].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[0][j].size()));
         }
-        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
-        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8448][j].size()));
-
-      }
-
-      for(unsigned j=0; j<7;j++){ // Module 768,8960 - STC4A
-        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
-        if(j<5){
-          chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
+        for (unsigned j = 0; j < 3; j++) {  //STC16 (mod 3-4) - 3 bins, 1TC/bin
+          for (unsigned i = 3; i < 5; i++) {
+            chn_frame_slots_per_mod_and_col_[i + iModGroup * 5][j].push_back(std::make_pair(0, 0));
+            max_tcs_per_module_and_column_[i + iModGroup * 5].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[i][j].size()));
+          }
         }
-        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
-        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
-      }
-
-
-      for(unsigned j=0; j<3;j++){ // Module 1280,9472 - CTC4A in Jul TB 
-        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
-        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
-        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
-        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
+        for (unsigned j = 0; j < 7; j++) {  //STC4 (mod 2) - 7 bins, 2TC/bin bin 1-5; 1TC/bin rest
+          chn_frame_slots_per_mod_and_col_[2 + iModGroup * 5][j].push_back(std::make_pair(0, 0));
+          if (j < 5) {
+            chn_frame_slots_per_mod_and_col_[2 + iModGroup * 5][j].push_back(std::make_pair(0, 0));
+          }
+          max_tcs_per_module_and_column_[2 + iModGroup * 5].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[2][j].size()));
+        }
       }
     }
 
-    void configureSeptemberTestBeamMappingInfo(){
-      for(unsigned j=0;j<9; j++){ //Module 256 - BC, 9 bins with first two having 2 slots, Module 768 - BC, 9 bins, Module 1280 - BC, 9 bins, 5 with 2 TC/bin, 8448 - STC16, 9 bins with first first 5 bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
-      //In the third train: 16640 - STC4, as 256; Module 17152, as 768. Module 24832: as 1280. Module 25344: as 8448
-        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[17152][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0,0));
-        if (j<2){
-          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
+    void configureTestBeamMappingInfo() {
+      for (unsigned j = 0; j < 7; j++) {  //Module 256, 8448 - BC (high occ for now)
+        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0, 0));
+        if (j < 2) {
+          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0, 0));
         }
-        if (j<5){
-          chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0,0));
-        }
-        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
-        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
-        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
-        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8448][j].size()));
-        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
-        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
-        max_tcs_per_module_and_column_[16640].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[16640][j].size()));
-        max_tcs_per_module_and_column_[17152].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[17152][j].size()));
-        max_tcs_per_module_and_column_[24832].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[24832][j].size()));
-        max_tcs_per_module_and_column_[25344].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[25344][j].size()));
+        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[256][j].size()));
+        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[8448][j].size()));
       }
 
+      for (unsigned j = 0; j < 7; j++) {  // Module 768,8960 - STC4A
+        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0, 0));
+        if (j < 5) {
+          chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0, 0));
+        }
+        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[768][j].size()));
+        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[8960][j].size()));
+      }
+
+      for (unsigned j = 0; j < 3; j++) {  // Module 1280,9472 - CTC4A in Jul TB
+        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0, 0));
+        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[1280][j].size()));
+        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0, 0));
+        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[9472][j].size()));
+      }
     }
 
-    void configureTDAQReadoutInfo(){
-      for(unsigned j=0; j<9; j++){
-        //Module 256: 9 bins, 2 slots for the first two. 768: 4 bins, 1 slot/bin. 1280: 4 bins, 1 slot/bin. 8448: 9 bins, 2 slots for the first two. 8960: 9 bins. 9472: 0 bins. 16640: 8 bins in TDAQ output, 2 slots for the first 2. 17152: 4 bins. 24832 : 4 bins. 25344 : 9 bins, 2 slots for the first 2 
-        tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,0)); //This means bin j, slot 0. 
-        tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,0));
-        tdaq_slots_per_bin_per_mod_[8960].push_back(std::make_pair(j,0));
-        tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j,0));
-        if(j<2){
-          tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,1));
-          tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,1));
-          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,1));
-          tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j,1));
-        } 
-        if(j<4){
-          tdaq_slots_per_bin_per_mod_[768].push_back(std::make_pair(j,0));
-          tdaq_slots_per_bin_per_mod_[1280].push_back(std::make_pair(j,0));
-          tdaq_slots_per_bin_per_mod_[17152].push_back(std::make_pair(j,0));
-          tdaq_slots_per_bin_per_mod_[24832].push_back(std::make_pair(j,0));
+    void configureSeptemberTestBeamMappingInfo() {
+      for (unsigned j = 0; j < 9;
+           j++) {  //Module 256 - BC, 9 bins with first two having 2 slots, Module 768 - BC, 9 bins, Module 1280 - BC, 9 bins, 5 with 2 TC/bin, 8448 - STC16, 9 bins with first first 5 bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
+                   //In the third train: 16640 - STC4, as 256; Module 17152, as 768. Module 24832: as 1280. Module 25344: as 8448
+        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[17152][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0, 0));
+        chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0, 0));
+        if (j < 2) {
+          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0, 0));
         }
-        if(j<8){ //Only to match the observed output where the last TC that is supposed to be read out is missing. In reality 9 TCs read out.
-          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,0));
+        if (j < 5) {
+          chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0, 0));
+          chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0, 0));
+        }
+        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[256][j].size()));
+        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[768][j].size()));
+        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[1280][j].size()));
+        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[8448][j].size()));
+        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[8960][j].size()));
+        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[9472][j].size()));
+        max_tcs_per_module_and_column_[16640].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[16640][j].size()));
+        max_tcs_per_module_and_column_[17152].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[17152][j].size()));
+        max_tcs_per_module_and_column_[24832].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[24832][j].size()));
+        max_tcs_per_module_and_column_[25344].push_back(std::make_pair(j, chn_frame_slots_per_mod_and_col_[25344][j].size()));
+      }
+    }
+
+    void configureTDAQReadoutInfo() {
+      for (unsigned j = 0; j < 9; j++) {
+        //Module 256: 9 bins, 2 slots for the first two. 768: 4 bins, 1 slot/bin. 1280: 4 bins, 1 slot/bin. 8448: 9 bins, 2 slots for the first two. 8960: 9 bins. 9472: 0 bins. 16640: 8 bins in TDAQ output, 2 slots for the first 2. 17152: 4 bins. 24832 : 4 bins. 25344 : 9 bins, 2 slots for the first 2
+        tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j, 0));  //This means bin j, slot 0.
+        tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j, 0));
+        tdaq_slots_per_bin_per_mod_[8960].push_back(std::make_pair(j, 0));
+        tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j, 0));
+        if (j < 2) {
+          tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j, 1));
+          tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j, 1));
+          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j, 1));
+          tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j, 1));
+        }
+        if (j < 4) {
+          tdaq_slots_per_bin_per_mod_[768].push_back(std::make_pair(j, 0));
+          tdaq_slots_per_bin_per_mod_[1280].push_back(std::make_pair(j, 0));
+          tdaq_slots_per_bin_per_mod_[17152].push_back(std::make_pair(j, 0));
+          tdaq_slots_per_bin_per_mod_[24832].push_back(std::make_pair(j, 0));
+        }
+        if (j < 8) {  //Only to match the observed output where the last TC that is supposed to be read out is missing. In reality 9 TCs read out.
+          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j, 0));
         }
       }
     }
 
     unsigned phiSector() const { return sector120_; }
     uint32_t fpgaID() const { return fpga_id_; }
-    bool modIsConfigured(unsigned moduleId) const{
-      return max_tcs_per_module_and_column_.count(moduleId);
-    }
-    unsigned getNumberOfColumns(unsigned moduleId) const {
-      return max_tcs_per_module_and_column_.at(moduleId).size();
-    }
+    bool modIsConfigured(unsigned moduleId) const { return max_tcs_per_module_and_column_.count(moduleId); }
+    unsigned getNumberOfColumns(unsigned moduleId) const { return max_tcs_per_module_and_column_.at(moduleId).size(); }
     unsigned getColBudgetAtIndex(unsigned moduleId, unsigned theColumnIndex) const {
       return max_tcs_per_module_and_column_.at(moduleId).at(theColumnIndex).second;
     }  //Get TC budget for column at index theColumnIndex in the vector
@@ -176,22 +169,15 @@ namespace l1thgcfirmware {
     unsigned getFrameAtIndex(unsigned moduleId, int theColumn, unsigned theChnFrameIndex) const {
       return chn_frame_slots_per_mod_and_col_.at(moduleId).at(theColumn).at(theChnFrameIndex).second;
     }  //Extract frame number for colnr theColumn, at given channel+frame index in the vector
-    std::vector<std::pair<unsigned,unsigned>> getTDAQSlotsForModule(unsigned moduleId) const {
-      return tdaq_slots_per_bin_per_mod_.at(moduleId);
-    }
-    unsigned isModuleReadByTDAQ(unsigned moduleId) const {
-      return tdaq_slots_per_bin_per_mod_.count(moduleId);
-    }
-
+    std::vector<std::pair<unsigned, unsigned>> getTDAQSlotsForModule(unsigned moduleId) const { return tdaq_slots_per_bin_per_mod_.at(moduleId); }
+    unsigned isModuleReadByTDAQ(unsigned moduleId) const { return tdaq_slots_per_bin_per_mod_.count(moduleId); }
 
   private:
     unsigned sector120_;
     uint32_t fpga_id_;
     std::unordered_map<unsigned, std::vector<std::pair<int, unsigned>>> max_tcs_per_module_and_column_;
-    std::unordered_map<unsigned, std::unordered_map<int, std::vector<std::pair<unsigned, unsigned>>>>
-        chn_frame_slots_per_mod_and_col_;
-    std::unordered_map<unsigned, std::vector<std::pair<unsigned, unsigned>>>
-        tdaq_slots_per_bin_per_mod_;
+    std::unordered_map<unsigned, std::unordered_map<int, std::vector<std::pair<unsigned, unsigned>>>> chn_frame_slots_per_mod_and_col_;
+    std::unordered_map<unsigned, std::vector<std::pair<unsigned, unsigned>>> tdaq_slots_per_bin_per_mod_;
     //const uint32_t dummyModId_ = 1879048191;  // Just to avoid filling maps for random module ID values. Temporary!!
   };
 

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -96,7 +96,7 @@ namespace l1thgcfirmware {
 
     void configureSeptemberTestBeamMappingInfo(){
       for(unsigned j=0;j<9; j++){ //Module 256 - BC, 9 bins with first two having 2 slots, Module 768 - BC, 9 bins, Module 1280 - BC, 9 bins, 5 with 2 TC/bin, 8448 - STC16, 9 bins with first first 5 bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
-      //In the third train: 16640 - STC4, as 256
+      //In the third train: 16640 - STC4, as 256; Module 17152, as 768. Module 24832: as 1280. Module 25344: as 8448
         chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
@@ -104,14 +104,18 @@ namespace l1thgcfirmware {
         chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[17152][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0,0));
         if (j<2){
           chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
           chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
         }
         if (j<5){
           chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[24832][j].push_back(std::make_pair(0,0));
           chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
-
+          chn_frame_slots_per_mod_and_col_[25344][j].push_back(std::make_pair(0,0));
         }
         max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
         max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
@@ -120,25 +124,34 @@ namespace l1thgcfirmware {
         max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
         max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
         max_tcs_per_module_and_column_[16640].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[16640][j].size()));
+        max_tcs_per_module_and_column_[17152].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[17152][j].size()));
+        max_tcs_per_module_and_column_[24832].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[24832][j].size()));
+        max_tcs_per_module_and_column_[25344].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[25344][j].size()));
       }
 
     }
 
     void configureTDAQReadoutInfo(){
       for(unsigned j=0; j<9; j++){
-        //Module 256: 9 bins, 2 slots for the first two. 768: 4 bins, 1 slot/bin. 1280: 4 bins, 1 slot/bin. 8448: 9 bins, 2 slots for the first two. 8960: 9 bins. 9472: 0 bins. 16640: 9 bins, 2 slots for the first 2.
+        //Module 256: 9 bins, 2 slots for the first two. 768: 4 bins, 1 slot/bin. 1280: 4 bins, 1 slot/bin. 8448: 9 bins, 2 slots for the first two. 8960: 9 bins. 9472: 0 bins. 16640: 8 bins in TDAQ output, 2 slots for the first 2. 17152: 4 bins. 24832 : 4 bins. 25344 : 9 bins, 2 slots for the first 2 
         tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,0)); //This means bin j, slot 0. 
         tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,0));
-        tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,0));
         tdaq_slots_per_bin_per_mod_[8960].push_back(std::make_pair(j,0));
+        tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j,0));
         if(j<2){
           tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,1));
           tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,1));
           tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,1));
+          tdaq_slots_per_bin_per_mod_[25344].push_back(std::make_pair(j,1));
         } 
         if(j<4){
           tdaq_slots_per_bin_per_mod_[768].push_back(std::make_pair(j,0));
           tdaq_slots_per_bin_per_mod_[1280].push_back(std::make_pair(j,0));
+          tdaq_slots_per_bin_per_mod_[17152].push_back(std::make_pair(j,0));
+          tdaq_slots_per_bin_per_mod_[24832].push_back(std::make_pair(j,0));
+        }
+        if(j<8){
+          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,0));
         }
       }
     }

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -94,8 +94,42 @@ namespace l1thgcfirmware {
       }
     }
 
+    void configureSeptemberTestBeamMappingInfo(){
+      for(unsigned j=0;j<9; j++){ //Module 256 - BC, and 8448 - STC16, 9 bins with first two bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
+      //In the third train: 16640 - STC4, as 256
+        chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
+        if (j<2){
+          chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
+        }
+        max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
+        max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8448][j].size()));
+        max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
+        max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
+        max_tcs_per_module_and_column_[16640].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[16640][j].size()));
+      }
+
+      for(unsigned j=0;j<4;j++) { //Module 768, 1280 - BC, 4 bins read out
+        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
+        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
+        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
+      }
+    }
+
     unsigned phiSector() const { return sector120_; }
     uint32_t fpgaID() const { return fpga_id_; }
+    bool modIsConfigured(unsigned moduleId) const{
+      return max_tcs_per_module_and_column_.count(moduleId);
+    }
+    unsigned getNumberOfColumns(unsigned moduleId) const {
+      return max_tcs_per_module_and_column_.at(moduleId).size();
+    }
     unsigned getColBudgetAtIndex(unsigned moduleId, unsigned theColumnIndex) const {
       return max_tcs_per_module_and_column_.at(moduleId).at(theColumnIndex).second;
     }  //Get TC budget for column at index theColumnIndex in the vector
@@ -108,6 +142,7 @@ namespace l1thgcfirmware {
     unsigned getFrameAtIndex(unsigned moduleId, int theColumn, unsigned theChnFrameIndex) const {
       return chn_frame_slots_per_mod_and_col_.at(moduleId).at(theColumn).at(theChnFrameIndex).second;
     }  //Extract frame number for colnr theColumn, at given channel+frame index in the vector
+
 
   private:
     unsigned sector120_;

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -95,30 +95,51 @@ namespace l1thgcfirmware {
     }
 
     void configureSeptemberTestBeamMappingInfo(){
-      for(unsigned j=0;j<9; j++){ //Module 256 - BC, and 8448 - STC16, 9 bins with first two bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
+      for(unsigned j=0;j<9; j++){ //Module 256 - BC, 9 bins with first two having 2 slots, Module 768 - BC, 9 bins, Module 1280 - BC, 9 bins, 5 with 2 TC/bin, 8448 - STC16, 9 bins with first first 5 bins having two slots; and 8960 - STC16, 9 bins. Treat 9472 similarly, even if not read out
       //In the third train: 16640 - STC4, as 256
         chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
+        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[8960][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[9472][j].push_back(std::make_pair(0,0));
         chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
         if (j<2){
           chn_frame_slots_per_mod_and_col_[256][j].push_back(std::make_pair(0,0));
-          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
           chn_frame_slots_per_mod_and_col_[16640][j].push_back(std::make_pair(0,0));
         }
+        if (j<5){
+          chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
+          chn_frame_slots_per_mod_and_col_[8448][j].push_back(std::make_pair(0,0));
+
+        }
         max_tcs_per_module_and_column_[256].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[256][j].size()));
+        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
+        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
         max_tcs_per_module_and_column_[8448].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8448][j].size()));
         max_tcs_per_module_and_column_[8960].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[8960][j].size()));
         max_tcs_per_module_and_column_[9472].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[9472][j].size()));
         max_tcs_per_module_and_column_[16640].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[16640][j].size()));
       }
 
-      for(unsigned j=0;j<4;j++) { //Module 768, 1280 - BC, 4 bins read out
-        chn_frame_slots_per_mod_and_col_[768][j].push_back(std::make_pair(0,0));
-        chn_frame_slots_per_mod_and_col_[1280][j].push_back(std::make_pair(0,0));
-        max_tcs_per_module_and_column_[768].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[768][j].size()));
-        max_tcs_per_module_and_column_[1280].push_back(std::make_pair(j,chn_frame_slots_per_mod_and_col_[1280][j].size()));
+    }
+
+    void configureTDAQReadoutInfo(){
+      for(unsigned j=0; j<9; j++){
+        //Module 256: 9 bins, 2 slots for the first two. 768: 4 bins, 1 slot/bin. 1280: 4 bins, 1 slot/bin. 8448: 9 bins, 2 slots for the first two. 8960: 9 bins. 9472: 0 bins. 16640: 9 bins, 2 slots for the first 2.
+        tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,0)); //This means bin j, slot 0. 
+        tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,0));
+        tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,0));
+        tdaq_slots_per_bin_per_mod_[8960].push_back(std::make_pair(j,0));
+        if(j<2){
+          tdaq_slots_per_bin_per_mod_[256].push_back(std::make_pair(j,1));
+          tdaq_slots_per_bin_per_mod_[8448].push_back(std::make_pair(j,1));
+          tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,1));
+        } 
+        if(j<4){
+          tdaq_slots_per_bin_per_mod_[768].push_back(std::make_pair(j,0));
+          tdaq_slots_per_bin_per_mod_[1280].push_back(std::make_pair(j,0));
+        }
       }
     }
 
@@ -142,6 +163,12 @@ namespace l1thgcfirmware {
     unsigned getFrameAtIndex(unsigned moduleId, int theColumn, unsigned theChnFrameIndex) const {
       return chn_frame_slots_per_mod_and_col_.at(moduleId).at(theColumn).at(theChnFrameIndex).second;
     }  //Extract frame number for colnr theColumn, at given channel+frame index in the vector
+    std::vector<std::pair<unsigned,unsigned>> getTDAQSlotsForModule(unsigned moduleId) const {
+      return tdaq_slots_per_bin_per_mod_.at(moduleId);
+    }
+    unsigned isModuleReadByTDAQ(unsigned moduleId) const {
+      return tdaq_slots_per_bin_per_mod_.count(moduleId);
+    }
 
 
   private:
@@ -150,6 +177,8 @@ namespace l1thgcfirmware {
     std::unordered_map<unsigned, std::vector<std::pair<int, unsigned>>> max_tcs_per_module_and_column_;
     std::unordered_map<unsigned, std::unordered_map<int, std::vector<std::pair<unsigned, unsigned>>>>
         chn_frame_slots_per_mod_and_col_;
+    std::unordered_map<unsigned, std::vector<std::pair<unsigned, unsigned>>>
+        tdaq_slots_per_bin_per_mod_;
     //const uint32_t dummyModId_ = 1879048191;  // Just to avoid filling maps for random module ID values. Temporary!!
   };
 

--- a/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
+++ b/TPGStage1Emulation/HGCalLayer1PhiOrderFwConfig.h
@@ -150,7 +150,7 @@ namespace l1thgcfirmware {
           tdaq_slots_per_bin_per_mod_[17152].push_back(std::make_pair(j,0));
           tdaq_slots_per_bin_per_mod_[24832].push_back(std::make_pair(j,0));
         }
-        if(j<8){
+        if(j<8){ //Only to match the observed output where the last TC that is supposed to be read out is missing. In reality 9 TCs read out.
           tdaq_slots_per_bin_per_mod_[16640].push_back(std::make_pair(j,0));
         }
       }

--- a/inc/TPGBEDataformat.hh
+++ b/inc/TPGBEDataformat.hh
@@ -505,6 +505,80 @@ private:
     uint32_t unpackedWords[7][2][8]; //7:bxs,2:stream,8:words per half 
   };
 
+
+  class TrigTCProcData{//Todo this could do with a print method!
+  public:
+    TrigTCProcData(){for (uint32_t ib=0;ib<7;ib++) for (uint32_t ibin=0;ibin<9;ibin++) for (uint32_t iinst=0;iinst<2;iinst++) unpackedWords[ib][ibin][iinst]=0;};
+    //void initUnpkWords(){for (uint32_t ib=0;ib<7;ib++) for (uint32_t ibin=0;ibin<9;ibin++) for (uint32_t iinst=0;iinst<2;iinst++) unpackedWords[ib][ibin][iinst]=0;}
+    void setUnpkWord(uint32_t ib, uint32_t ibin, uint32_t iinst, uint32_t val) { assert(ib<7) ; assert(ibin<9); assert(iinst<2); unpackedWords[ib][ibin][iinst] = val;}
+    int  getUnpkWord(uint32_t ib, uint32_t ibin, uint32_t iinst) const { return unpkWordIsValid(ib,ibin,iinst)? unpackedWords[ib][ibin][iinst] : -1;}
+    bool unpkWordIsValid(uint32_t ib, uint32_t ibin, uint32_t iinst) const {
+      if((unpackedWords[ib][ibin][iinst]&0x7FFF)!=0) return true;
+      else if(((unpackedWords[ib][ibin][iinst]&0x7FFF)==0) && ibin==0 && iinst==0 && ((unpackedWords[ib][ibin+1][iinst]&0x7FFF)!=0 || (unpackedWords[ib][ibin][iinst+1]&0x7FFF)!=0)) return true; 
+      else return false;
+    }
+    int getTDAQEntry(int ilp, int iecon) {
+      if (ilp==0) return 0;//first lpGBT link: all 3 ECON-Ts in first TDAQ block
+      else if (ilp==1&&iecon<2) return iecon; //second lpGBT link: first ECON-T is in first TDAQ block, second ECON-T in 2nd TDAQ block; third ECON-T not read out
+      else if(ilp==2) return 2; //third lpGBT link: all 3 ECON-Ts in the third TDAQ block
+      else if (ilp==3&&iecon<2) return iecon+2; //fourth lpGBT link: first ECON-T is in the third TDAQ block, second ECON-T is in the last TDAQ block; third ECON-T is not read out
+      else return -1;
+    }
+    std::map<int, std::vector<std::pair<int, int>>> getWordAndColPerBin(int ilp, int iecon ) {
+      std::map<int, std::vector<std::pair<int, int>>> theTmpMap;
+      std::vector<std::pair<int,int>> theTmpVec;
+      if ( (ilp==0||ilp==2) && iecon==0) { //first, third lpGBT link, first ECON-T: start at 1st word of the TDAQ block, has 9 bins (2 TC/bin in the first 2), 3 words in total
+        theTmpMap.clear();
+        for(int ibin =0 ; ibin <9 ; ibin++){
+          theTmpVec.resize(0);
+          if(ibin==0){
+            theTmpVec.push_back(std::make_pair(0,0));
+            theTmpVec.push_back(std::make_pair(0,1));
+          } else if (ibin==1) {
+            theTmpVec.push_back(std::make_pair(0,2));
+            theTmpVec.push_back(std::make_pair(0,3));
+          } else {
+            theTmpVec.push_back(std::make_pair(std::floor((ibin-2)/4)+1,(ibin-2)%4));
+          }
+          theTmpMap[ibin] = theTmpVec;
+        }
+      } else if((ilp==0 || ilp==2) &&iecon<3) {//first, third lpGBT link, second and third ECON-T: read out in the next 2 words, 4 bins (so 1 word per module)
+        theTmpMap.clear();
+        for(int ibin=0;ibin<4;ibin++){
+          theTmpVec.resize(0);
+          theTmpVec.push_back(std::make_pair(iecon+2,ibin)); //2nd and 3d module have 4 bins, one entry each
+          theTmpMap[ibin] = theTmpVec;
+        }
+      } else if((ilp==1 || ilp==3) && iecon ==0){//second, fourth lpGBT link, first ECON-T: last words of the TDAQ block, 9 bins (2TC/bin in the first 2), 3 words in total
+        theTmpMap.clear();
+        for(int ibin=0; ibin < 9 ; ibin++){
+          theTmpVec.resize(0);
+          if(ibin==0){
+            theTmpVec.push_back(std::make_pair(5,0));
+            theTmpVec.push_back(std::make_pair(5,1));
+          } else if (ibin==1){
+            theTmpVec.push_back(std::make_pair(5,2));
+            theTmpVec.push_back(std::make_pair(5,3));
+          } else {
+            theTmpVec.push_back(std::make_pair(std::floor((ibin-2)/4)+6,(ibin-2)%4));
+          }
+          theTmpMap[ibin] = theTmpVec;
+        }
+      } else if ((ilp==1 || ilp==3) && iecon ==1){//second, fourth lpGBT link, second ECON-T: first words of the next TDAQ block, 9 bins, 3 words in total. 
+        theTmpMap.clear();
+        for(int ibin=0; ibin<9;ibin++){
+          theTmpVec.resize(0);
+          theTmpVec.push_back(std::make_pair(std::floor(ibin/4),ibin%4));
+          theTmpMap[ibin] = theTmpVec;
+        }
+      }
+      return theTmpMap;
+    }
+
+  private:
+    uint32_t unpackedWords[7][9][2]; //7: bxs, 9: bins, 2: max entries per bin
+  };
+
 }
 
 #endif

--- a/inc/TPGFEReader3TSep2024.hh
+++ b/inc/TPGFEReader3TSep2024.hh
@@ -1191,7 +1191,7 @@ namespace TPGFEReader{
 	      iunpkw++;
 	    }
 	    if((nEvents < nShowEvents) or (scanMode and boe->eventId()==inspectEvent))
-	      std::cout<<"iloc: "<< iw
+		  std::cout<<"iloc: "<< iw
 		       << std::hex
 		       <<", col0 : 0x" << std::setfill('0') << std::setw(4) << col0 <<", "
 		       <<", col1 : 0x" << std::setfill('0') << std::setw(4) << col1 <<", "
@@ -1330,7 +1330,7 @@ namespace TPGFEReader{
 			 <<", col2 : 0x" << std::setfill('0') << std::setw(4) << col2 <<", "
 			 <<", col3 : 0x" << std::setfill('0') << std::setw(4) << col3 <<", "
 			 << std::dec << std::setfill(' ')
-			 << std::endl;		
+			 << std::endl;	
 	      unpkIndx++;
 	      if(unpkIndx%8==0) {ibx++; iunpkw=0;}
 	    }//loop over words for 7 bxs
@@ -1339,7 +1339,8 @@ namespace TPGFEReader{
 	  ///////////////////// Fill tcprocarray ///////////////////////
 	  TPGBEDataformat::TrigTCProcData tcprocdata[4][3]; //4:lpGBT, 3:econT
 	  for(int ilp=0;ilp<4;ilp++){
-	    for(int iecon=0;iecon<3;iecon++){
+		unsigned maxecons = ilp<2 ? 3:2;
+	    for(int iecon=0;iecon< maxecons;iecon++){//2 ECON-Ts in trains 3 and 4
 	      moduleId = pck.packModId(zside, sector, ilp, det, iecon, selTC4, module);
 		  int theTDAQEntry = tcprocdata[ilp][iecon].getTDAQEntry(ilp,iecon);
 		  std::map<int, std::vector<std::pair<int, int>>> theWordAndColPerBin = tcprocdata[ilp][iecon].getWordAndColPerBin(ilp,iecon);

--- a/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
+++ b/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
   uint32_t runNumber(0);
   uint32_t linkNumber(0);
   uint64_t totEvents(0);
-  uint64_t nofEvents(100);
+  uint64_t nofEvents(10);
   std::istringstream issRelay(argv[1]);
   issRelay >> relayNumber;
   //Notes:
@@ -268,10 +268,14 @@ int main(int argc, char** argv)
 	    if(econtdata.at(ietd).first!=moduleId) continue;//Need to assume that order of econtdata and tcprocdata entries is the same.
 	    trdata = econtdata.at(ietd).second ;
       tcpdata = tcprocdata.at(ietd).second;
+      std::cout<<"=======================TC processor data==================="<<std::endl;
+      std::cout<<moduleId <<std::endl;
+      //tcpdata.print(3);
+
       triggerCellsFromTriggerData = createTCsFromTriggerData(moduleId,tcpdata);
-	    std::cout << "Dataloop:: event: " << event << ", moduleId : " << econtdata.at(ietd).first << " moduleId from tcproc data "<<tcprocdata.at(ietd).first << std::endl;
-	    //for(int ibx=0;ibx<7;ibx++){
-	    for(int ibx=3;ibx<4;ibx++){
+	    //std::cout << "Dataloop:: event: " << event << ", moduleId : " << econtdata.at(ietd).first << " moduleId from tcproc data "<<tcprocdata.at(ietd).first << std::endl;
+	    for(int ibx=0;ibx<7;ibx++){
+	    //for(int ibx=3;ibx<4;ibx++){
 	      const uint32_t *el = trdata.getElinks(ibx); 
 	      uint32_t bx_2 = (el[0]>>28) & 0xF;
 	      if(ilink==0) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, econTPar[moduleId].getNofTCs(), el, vTCel);
@@ -284,9 +288,9 @@ int main(int argc, char** argv)
 	      //==================================================================
 	      //TPGStage1Emulation::Stage1IO::convertUnpackerOutputStreamPairToTCProc(bx_2, updata, tcprocemul);
 	      //==================================================================
-	      std::cout << "========== ibx : " << ibx << " ==========" << std::endl;
-	      std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
-	      updata.print();
+	      //std::cout << "========== ibx : " << ibx << " ==========" << std::endl;
+	      //std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
+	      //updata.print();
 	      //==================================================================
 	      //TC proc emulation comparison with data something similar to below
 	      //==================================================================
@@ -312,7 +316,10 @@ int main(int argc, char** argv)
         if(isDataTCsAssigned){//Only try to do comparison if we have read out TB data since some modules are missing
           bool diffTCs=hasDifferentTCs(tcs_out_SA,tcs_out_tcproc_TB);
 
-          if(diffTCs || 1){
+          if(diffTCs){
+
+            std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
+	          updata.print();
             std::cout << "========== Emulated TC proc results using firmware data of Stage1 unpacker output stream for ibx : " << ibx << " ==========" << std::endl;
 
             std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from ECON-T elink input"<<std::endl;
@@ -326,6 +333,8 @@ int main(int argc, char** argv)
             for (auto& tcobj : tcs_out_tcproc_TB){
               std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
             }
+
+            std::cout << "========== end of TPG data for ibx : " << ibx << " ==========" << std::endl;
           }
           FillHistogram(dir_diff,tcs_out_SA,tcs_out_tcproc_TB);
         }
@@ -333,7 +342,6 @@ int main(int argc, char** argv)
 	      //trdata.getTCData(ibx,tcprocdata);
 	      //tcprocdata.print();
 	      //==================================================================
-	      std::cout << "========== end of TPG data for ibx : " << ibx << " ==========" << std::endl;
 	    }//bx loop
 	    //if(eventCondn) trdata.print();
 	  }//loop over econt data for a given run
@@ -473,6 +481,57 @@ void BookHistograms(TDirectory*& dir_diff, uint32_t relay){
   hTCProcDiff_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator");
   hTCProcDiff_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff256_quantities = new TH1D("hTCProcDiff256_quantities", Form("TC processor difference in output quantities mod 256 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff256_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 256");
+  hTCProcDiff256_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff256_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff768_quantities = new TH1D("hTCProcDiff768_quantities", Form("TC processor difference in output quantities mod 768 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff768_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 768");
+  hTCProcDiff768_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff768_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff1280_quantities = new TH1D("hTCProcDiff1280_quantities", Form("TC processor difference in output quantities mod 1280 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff1280_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 1280");
+  hTCProcDiff1280_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff1280_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff8448_quantities = new TH1D("hTCProcDiff8448_quantities", Form("TC processor difference in output quantities mod 8448 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff8448_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 8448");
+  hTCProcDiff8448_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff8448_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff8960_quantities = new TH1D("hTCProcDiff8960_quantities", Form("TC processor difference in output quantities mod 8960 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff8960_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 8960");
+  hTCProcDiff8960_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff8960_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff9472_quantities = new TH1D("hTCProcDiff9472_quantities", Form("TC processor difference in output quantities mod 9472 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff9472_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 9472");
+  hTCProcDiff9472_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff9472_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff16640_quantities = new TH1D("hTCProcDiff16640_quantities", Form("TC processor difference in output quantities mod 16640 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff16640_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 16640");
+  hTCProcDiff16640_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff16640_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff17152_quantities = new TH1D("hTCProcDiff17152_quantities", Form("TC processor difference in output quantities mod 17152 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff17152_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 17152");
+  hTCProcDiff17152_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff17152_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff24832_quantities = new TH1D("hTCProcDiff24832_quantities", Form("TC processor difference in output quantities mod 24832 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff24832_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 24832");
+  hTCProcDiff24832_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff24832_quantities->SetDirectory(dir_diff);
+
+  TH1D *hTCProcDiff25344_quantities = new TH1D("hTCProcDiff25344_quantities", Form("TC processor difference in output quantities mod 25344 for Relay: %u", relay),52,-0.5,25.5);
+  hTCProcDiff25344_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 25344");
+  hTCProcDiff25344_quantities->GetYaxis()->SetTitle("Entries");
+  hTCProcDiff25344_quantities->SetDirectory(dir_diff);
+
 }
 
 void FillHistogram(TDirectory*& dir_diff, l1thgcfirmware::HGCalTriggerCellSACollection tcProcEmulator, l1thgcfirmware::HGCalTriggerCellSACollection tcProcTB){
@@ -485,8 +544,20 @@ void FillHistogram(TDirectory*& dir_diff, l1thgcfirmware::HGCalTriggerCellSAColl
     }
     ((TH1D *) list->FindObject("hTCProcDiff_size"))->Fill(theTCListSizeDiff);
     unsigned theSizeToTest = std::min(tcProcEmulator.size(),tcProcTB.size());
+    unsigned theModuleId = 0;
+    if(theSizeToTest>0) theModuleId = tcProcEmulator.at(0).moduleId();
     for(unsigned i=0; i<theSizeToTest; i++){
       unsigned diffsize = std::abs(int(tcProcEmulator.at(i).energy()-tcProcTB.at(i).energy()))+std::abs(int(tcProcEmulator.at(i).phi()-tcProcTB.at(i).phi()))+std::abs(int(tcProcEmulator.at(i).channel()-tcProcTB.at(i).channel()))+std::abs(int(tcProcEmulator.at(i).frame()-tcProcTB.at(i).frame()))+std::abs(int(tcProcEmulator.at(i).column()-tcProcTB.at(i).column()));
       ((TH1D *) list->FindObject("hTCProcDiff_quantities"))->Fill(diffsize);
+      if(theModuleId==256) ((TH1D *) list->FindObject("hTCProcDiff256_quantities"))->Fill(diffsize);
+      else if(theModuleId==768) ((TH1D *) list->FindObject("hTCProcDiff768_quantities"))->Fill(diffsize);
+      else if(theModuleId==1280) ((TH1D *) list->FindObject("hTCProcDiff1280_quantities"))->Fill(diffsize);
+      else if(theModuleId==8448) ((TH1D *) list->FindObject("hTCProcDiff8448_quantities"))->Fill(diffsize);
+      else if(theModuleId==8960) ((TH1D *) list->FindObject("hTCProcDiff8960_quantities"))->Fill(diffsize);
+      else if(theModuleId==9472) ((TH1D *) list->FindObject("hTCProcDiff9472_quantities"))->Fill(diffsize);
+      else if(theModuleId==16640) ((TH1D *) list->FindObject("hTCProcDiff16640_quantities"))->Fill(diffsize);
+      else if(theModuleId==17152) ((TH1D *) list->FindObject("hTCProcDiff17152_quantities"))->Fill(diffsize);
+      else if(theModuleId==24832) ((TH1D *) list->FindObject("hTCProcDiff24832_quantities"))->Fill(diffsize);
+      else if(theModuleId==25344) ((TH1D *) list->FindObject("hTCProcDiff25344_quantities"))->Fill(diffsize);
     }
 }

--- a/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
+++ b/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
@@ -35,12 +35,10 @@
 #include "HGCalLayer1PhiOrderFwImpl.h"
 #include "HGCalTriggerCell_SA.h"
 
-int main(int argc, char** argv)
-{
-  
+int main(int argc, char **argv) {
   std::cout << "========= tpgdata_3T_tcproc================" << std::endl;
 
-  if(argc < 3){
+  if (argc < 3) {
     std::cerr << argv[0] << ": no relay and/or run numbers specified" << std::endl;
     return false;
   }
@@ -61,9 +59,8 @@ int main(int argc, char** argv)
   // 3. first technical with third layer : 1727099443 //https://cmsonline.cern.ch/webcenter/portal/cmsonline/Common/Elog?__adfpwp_action_portlet=683379043&__adfpwp_backurl=https%3A%2F%2Fcmsonline.cern.ch%3A443%2Fwebcenter%2Fportal%2Fcmsonline%2FCommon%2FElog%3F_afrRedirect%3D23225796808764440&_piref683379043.strutsAction=%2FviewMessageDetails.do%3FmsgId%3D1237840
   // 4. swap back roc2 config of mod16 for relays after 1727116899 (not necessary for this code, kept as bookkeeping)
   // 5. List of run flagged as green by Paul for TC Processor are Relay1727219172 to Run1727219175 and probably Relay1727211141
-  
 
-  if(relayNumber<1727099251){
+  if (relayNumber < 1727099251) {
     std::cerr << "Third layer is not properly configured" << std::endl;
     return false;
   }
@@ -71,29 +68,29 @@ int main(int argc, char** argv)
   std::istringstream issRun(argv[2]);
   issRun >> runNumber;
 
-  std::cout<<argc<<std::endl;
-  if(argc == 4){
+  std::cout << argc << std::endl;
+  if (argc == 4) {
     std::istringstream issnEvents(argv[3]);
     issnEvents >> nofEvents;
   }
 
   totEvents = getTotalNofEvents(relayNumber, runNumber);
-  if(nofEvents>totEvents){
-    nofEvents = totEvents ;
+  if (nofEvents > totEvents) {
+    nofEvents = totEvents;
     std::cout << "Setting number of events to process to " << nofEvents << std::endl;
   }
   //===============================================================================================================================
   //Helper functions
   l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDataformat::UnpackerOutputStreamPair> &);
   bool hasDifferentTCs(l1thgcfirmware::HGCalTriggerCellSACollection, l1thgcfirmware::HGCalTriggerCellSACollection);
-  std::map<uint32_t,l1thgcfirmware::HGCalTriggerCellSACollection> createTCsFromTriggerData(uint32_t, TPGBEDataformat::TrigTCProcData);//ibx
+  std::map<uint32_t, l1thgcfirmware::HGCalTriggerCellSACollection> createTCsFromTriggerData(uint32_t, TPGBEDataformat::TrigTCProcData);  //ibx
 
   //===============================================================================================================================
   //Book histograms
   //===============================================================================================================================
-  void BookHistograms(TDirectory*&, uint32_t);
-  void FillHistogram( TDirectory*&, l1thgcfirmware::HGCalTriggerCellSACollection, l1thgcfirmware::HGCalTriggerCellSACollection);
-  TFile *fout = new TFile(Form("Diff_TCProc_Relay-%u.root",relayNumber),"recreate");
+  void BookHistograms(TDirectory *&, uint32_t);
+  void FillHistogram(TDirectory *&, l1thgcfirmware::HGCalTriggerCellSACollection, l1thgcfirmware::HGCalTriggerCellSACollection);
+  TFile *fout = new TFile(Form("Diff_TCProc_Relay-%u.root", relayNumber), "recreate");
   TDirectory *dir_diff = fout->mkdir("diff_plots");
   BookHistograms(dir_diff, relayNumber);
   //===============================================================================================================================
@@ -117,89 +114,105 @@ int main(int argc, char** argv)
   uint32_t econt = 0, selTC4 = 1, module = 0;
   uint32_t noflpGBTs = 4;
   TPGFEConfiguration::TPGFEIdPacking pck;
-  for(int ilink=0;ilink<noflpGBTs;ilink++){
-    int maxecons = (ilink<=1)?3:2;
-    for(int iecont=0;iecont<maxecons ;iecont++){
-      uint32_t idx = pck.packModId(zside, sector, ilink, det, iecont, selTC4, module); 
+  for (int ilink = 0; ilink < noflpGBTs; ilink++) {
+    int maxecons = (ilink <= 1) ? 3 : 2;
+    for (int iecont = 0; iecont < maxecons; iecont++) {
+      uint32_t idx = pck.packModId(zside, sector, ilink, det, iecont, selTC4, module);
       cfgs.setModulePath(zside, sector, ilink, det, iecont, selTC4, module);
-      cfgs.setEconTFile("cfgmap/init_econt.yaml"); //read a dummy econt since the original was not available earlier
+      cfgs.setEconTFile("cfgmap/init_econt.yaml");  //read a dummy econt since the original was not available earlier
       cfgs.readEconTConfigYaml();
-    }//econt loop
-  }//lpGBT loop
+    }  //econt loop
+  }    //lpGBT loop
 
   //Step2: update all ECON-T configs corresponding to test-beam after the inclusion of third train
-  link = 0; econt = 0; uint32_t lp0_bc0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 0; econt = 1; uint32_t lp0_bc1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 0; econt = 2; uint32_t lp0_bc2 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 1; econt = 0; uint32_t lp1_stc160 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 1; econt = 1; uint32_t lp1_stc161 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 1; econt = 2; uint32_t lp1_stc162 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 2; econt = 0; uint32_t lp2_stc4a0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 2; econt = 1; uint32_t lp2_stc4a1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 3; econt = 0; uint32_t lp3_stc4a0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  link = 3; econt = 1; uint32_t lp3_stc4a1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
-  
+  link = 0;
+  econt = 0;
+  uint32_t lp0_bc0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 0;
+  econt = 1;
+  uint32_t lp0_bc1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 0;
+  econt = 2;
+  uint32_t lp0_bc2 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 1;
+  econt = 0;
+  uint32_t lp1_stc160 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 1;
+  econt = 1;
+  uint32_t lp1_stc161 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 1;
+  econt = 2;
+  uint32_t lp1_stc162 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 2;
+  econt = 0;
+  uint32_t lp2_stc4a0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 2;
+  econt = 1;
+  uint32_t lp2_stc4a1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 3;
+  econt = 0;
+  uint32_t lp3_stc4a0 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+  link = 3;
+  econt = 1;
+  uint32_t lp3_stc4a1 = pck.packModId(zside, sector, link, det, econt, selTC4, module);
+
   uint32_t density(0);
   uint32_t droplsb(1);
-  std::map<uint32_t,TPGFEConfiguration::ConfigEconT>& econTPar =  cfgs.getEconTPara();
-  for(const auto& it : econTPar){
+  std::map<uint32_t, TPGFEConfiguration::ConfigEconT> &econTPar = cfgs.getEconTPara();
+  for (const auto &it : econTPar) {
     econTPar[it.first].setDensity(density);
     econTPar[it.first].setDropLSB(droplsb);
-    
-    if(it.first==lp0_bc0){              //// starting 1st train
+
+    if (it.first == lp0_bc0) {  //// starting 1st train
       econTPar[it.first].setSelect(2);
-      econTPar[it.first].setNElinks(3);      
-    }else if (it.first==lp0_bc1){
-      econTPar[it.first].setSelect(2);
-      econTPar[it.first].setNElinks(2);     
-    }else if (it.first==lp0_bc2){
+      econTPar[it.first].setNElinks(3);
+    } else if (it.first == lp0_bc1) {
       econTPar[it.first].setSelect(2);
       econTPar[it.first].setNElinks(2);
-    }else if (it.first==lp1_stc160){    //// starting 2nd train
+    } else if (it.first == lp0_bc2) {
+      econTPar[it.first].setSelect(2);
+      econTPar[it.first].setNElinks(2);
+    } else if (it.first == lp1_stc160) {  //// starting 2nd train
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(1);
-    }else if (it.first==lp1_stc161){
+    } else if (it.first == lp1_stc161) {
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(1);
-    }else if (it.first==lp1_stc162){
+    } else if (it.first == lp1_stc162) {
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(1);
-    }else if (it.first==lp2_stc4a0){    //// starting 3rd train
+    } else if (it.first == lp2_stc4a0) {  //// starting 3rd train
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(4);
       econTPar[it.first].setSTCType(3);
-    }else if (it.first==lp2_stc4a1){
+    } else if (it.first == lp2_stc4a1) {
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(2);
       econTPar[it.first].setSTCType(3);
-    }else if (it.first==lp3_stc4a0){    //// starting motherboard
+    } else if (it.first == lp3_stc4a0) {  //// starting motherboard
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(4);
       econTPar[it.first].setSTCType(3);
-    }else if (it.first==lp3_stc4a1){
+    } else if (it.first == lp3_stc4a1) {
       econTPar[it.first].setSelect(1);
       econTPar[it.first].setNElinks(3);
       econTPar[it.first].setSTCType(3);
     }
-    std::cout << "Modtype " << it.first
-	      << ", getOuttype: " << econTPar[it.first].getOutType()
-	      << ", select: " << econTPar[it.first].getSelect()
-      	      << ", stctype: " << econTPar[it.first].getSTCType()
-	      << ", typename: " << TPGFEDataformat::tctypeName[econTPar[it.first].getOutType()]
-	      << std::endl;
+    std::cout << "Modtype " << it.first << ", getOuttype: " << econTPar[it.first].getOutType() << ", select: " << econTPar[it.first].getSelect()
+              << ", stctype: " << econTPar[it.first].getSTCType() << ", typename: " << TPGFEDataformat::tctypeName[econTPar[it.first].getOutType()] << std::endl;
     econTPar[it.first].print();
-  }//econt loop
+  }  //econt loop
   //===============================================================================================================================
-  
+
   // ===============================================================================================================================
   // Set and Initialize the ECONT reader
   // ===============================================================================================================================
   TPGFEReader::ECONTReader econTReader(cfgs);
-  std::map<uint64_t,std::vector<std::pair<uint32_t,TPGBEDataformat::Trig24Data>>> econtarray; //event,moduleId (from link)
-  std::map<uint64_t,std::vector<std::pair<uint32_t,TPGBEDataformat::TrigTCProcData>>> tcprocarray; //event,moduleId (from link)
+  std::map<uint64_t, std::vector<std::pair<uint32_t, TPGBEDataformat::Trig24Data>>> econtarray;       //event,moduleId (from link)
+  std::map<uint64_t, std::vector<std::pair<uint32_t, TPGBEDataformat::TrigTCProcData>>> tcprocarray;  //event,moduleId (from link)
   econTReader.setNofCAFESep(14);
   // ===============================================================================================================================
 
@@ -215,349 +228,369 @@ int main(int argc, char** argv)
   //===============================================================================================================================
   /*TcTp1 events */ uint64_t refEvt[2] = {19, 137};
   std::vector<uint64_t> refEvents;
-  for(int ievent=0;ievent<2;ievent++) refEvents.push_back(refEvt[ievent]);
+  for (int ievent = 0; ievent < 2; ievent++)
+    refEvents.push_back(refEvt[ievent]);
   //when the following line is "commented" only the events filled in "refEvents" will be processed instead of nofevents set in the command line
   refEvents.resize(0);
   //===============================================================================================================================
 
-  uint64_t minEventTPG, maxEventTPG;  
-  long double nloopEvent =  100000;
-  int nloop = TMath::CeilNint(nofEvents/nloopEvent) ;
-  if(refEvents.size()>0) nloop = 1;
-  std::cout<<"nloop: "<<nloop<<std::endl;
+  uint64_t minEventTPG, maxEventTPG;
+  long double nloopEvent = 100000;
+  int nloop = TMath::CeilNint(nofEvents / nloopEvent);
+  if (refEvents.size() > 0)
+    nloop = 1;
+  std::cout << "nloop: " << nloop << std::endl;
 
-  for(int ieloop=0;ieloop<nloop;ieloop++){
-    
-    minEventTPG = ieloop*nloopEvent ;
-    maxEventTPG = (ieloop+1)*nloopEvent;
-    maxEventTPG = (maxEventTPG>uint64_t(nofEvents)) ? uint64_t(nofEvents) : maxEventTPG ;
-    printf("iloop : %d, minEventTPG = %lu, maxEventTPG = %lu\n",ieloop,minEventTPG, maxEventTPG);
-    std::cerr<<"iloop : "<< ieloop <<", minEventTPG = "<< minEventTPG <<", maxEventTPG = " << maxEventTPG << std::endl;
+  for (int ieloop = 0; ieloop < nloop; ieloop++) {
+    minEventTPG = ieloop * nloopEvent;
+    maxEventTPG = (ieloop + 1) * nloopEvent;
+    maxEventTPG = (maxEventTPG > uint64_t(nofEvents)) ? uint64_t(nofEvents) : maxEventTPG;
+    printf("iloop : %d, minEventTPG = %lu, maxEventTPG = %lu\n", ieloop, minEventTPG, maxEventTPG);
+    std::cerr << "iloop : " << ieloop << ", minEventTPG = " << minEventTPG << ", maxEventTPG = " << maxEventTPG << std::endl;
 
     econtarray.clear();
     tcprocarray.clear();
-    
-    econTReader.init(relayNumber,runNumber,0);
-    std::cout<<"TRIG Before: elink and unpacker size : " << econtarray.size() << ", tcprocarray.size(): " << tcprocarray.size() <<std::endl;
+
+    econTReader.init(relayNumber, runNumber, 0);
+    std::cout << "TRIG Before: elink and unpacker size : " << econtarray.size() << ", tcprocarray.size(): " << tcprocarray.size() << std::endl;
     econTReader.getEvents(refEvents, minEventTPG, maxEventTPG, econtarray, tcprocarray);
-    std::cout<<"TRIG After:  elink and unpacker size : " << econtarray.size() << ", tcprocarray.size(): " << tcprocarray.size() <<std::endl;
+    std::cout << "TRIG After:  elink and unpacker size : " << econtarray.size() << ", tcprocarray.size(): " << tcprocarray.size() << std::endl;
     econTReader.terminate();
-    
-    for( auto& it :  econtarray){ //this is essencially event loop
-      uint64_t event = it.first ;
+
+    for (auto &it : econtarray) {  //this is essencially event loop
+      uint64_t event = it.first;
       std::cout << "Processing event: " << event << std::endl;
-      std::map<uint32_t,l1thgcfirmware::HGCalTriggerCellSACollection> triggerCellsFromTriggerData;
-      for(int ilink=0;ilink<noflpGBTs;ilink++){
-	int maxecons = (ilink<=1)?3:2;
-	for(int iecont=0;iecont<maxecons;iecont++){
-	  uint32_t moduleId = pck.packModId(zside, sector, ilink, det, iecont, selTC4, module); 
-	  std::vector<std::pair<uint32_t,TPGBEDataformat::Trig24Data>> econtdata =  econtarray[event];
-    std::vector<std::pair<uint32_t,TPGBEDataformat::TrigTCProcData>> tcprocdata = tcprocarray[event];	  
-	  TPGBEDataformat::UnpackerOutputStreamPair upemul,updata;
-	  TPGFEDataformat::TcRawDataPacket vTCel;	
-	  TPGBEDataformat::Trig24Data trdata;
-    TPGBEDataformat::TrigTCProcData tcpdata;
-    std::vector<TPGBEDataformat::UnpackerOutputStreamPair> theOutputStreams;
-    l1thgcfirmware::HGCalTriggerCellSACollection theTCsFromOS;
-    l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_SA; //output from elink data
-    l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_tcproc_TB; //trigger cell output from tc processor in testbeam
-    l1thgcfirmware::HGCalLayer1PhiOrderFwImpl theAlgo_;
-	  
-	  //for(const auto& econtit : econtdata){
-    for(uint32_t ietd= 0; ietd < econtdata.size(); ietd++){
-	    if(econtdata.at(ietd).first!=moduleId) continue;//Need to assume that order of econtdata and tcprocdata entries is the same.
-	    trdata = econtdata.at(ietd).second ;
-      tcpdata = tcprocdata.at(ietd).second;
-      std::cout<<"=======================TC processor data==================="<<std::endl;
-      std::cout<<moduleId <<std::endl;
-      //tcpdata.print(3);
+      std::map<uint32_t, l1thgcfirmware::HGCalTriggerCellSACollection> triggerCellsFromTriggerData;
+      for (int ilink = 0; ilink < noflpGBTs; ilink++) {
+        int maxecons = (ilink <= 1) ? 3 : 2;
+        for (int iecont = 0; iecont < maxecons; iecont++) {
+          uint32_t moduleId = pck.packModId(zside, sector, ilink, det, iecont, selTC4, module);
+          std::vector<std::pair<uint32_t, TPGBEDataformat::Trig24Data>> econtdata = econtarray[event];
+          std::vector<std::pair<uint32_t, TPGBEDataformat::TrigTCProcData>> tcprocdata = tcprocarray[event];
+          TPGBEDataformat::UnpackerOutputStreamPair upemul, updata;
+          TPGFEDataformat::TcRawDataPacket vTCel;
+          TPGBEDataformat::Trig24Data trdata;
+          TPGBEDataformat::TrigTCProcData tcpdata;
+          std::vector<TPGBEDataformat::UnpackerOutputStreamPair> theOutputStreams;
+          l1thgcfirmware::HGCalTriggerCellSACollection theTCsFromOS;
+          l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_SA;         //output from elink data
+          l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_tcproc_TB;  //trigger cell output from tc processor in testbeam
+          l1thgcfirmware::HGCalLayer1PhiOrderFwImpl theAlgo_;
 
-      triggerCellsFromTriggerData = createTCsFromTriggerData(moduleId,tcpdata);
-	    //std::cout << "Dataloop:: event: " << event << ", moduleId : " << econtdata.at(ietd).first << " moduleId from tcproc data "<<tcprocdata.at(ietd).first << std::endl;
-	    for(int ibx=0;ibx<7;ibx++){
-	    //for(int ibx=3;ibx<4;ibx++){
-	      const uint32_t *el = trdata.getElinks(ibx); 
-	      uint32_t bx_2 = (el[0]>>28) & 0xF;
-	      if(ilink==0) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, econTPar[moduleId].getNofTCs(), el, vTCel);
-	      if(ilink==1) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, econTPar[moduleId].getNofSTCs(), el, vTCel);
-	      if(ilink==2 or ilink==3) TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, econTPar[moduleId].getNofSTCs(), el, vTCel);
-	      trdata.getUnpkStream(ibx,updata);
-        updata.setModuleId(moduleId);
-	      //==================================================================
-	      //TC proc emulation something similar to below
-	      //==================================================================
-	      //TPGStage1Emulation::Stage1IO::convertUnpackerOutputStreamPairToTCProc(bx_2, updata, tcprocemul);
-	      //==================================================================
-	      //std::cout << "========== ibx : " << ibx << " ==========" << std::endl;
-	      //std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
-	      //updata.print();
-	      //==================================================================
-	      //TC proc emulation comparison with data something similar to below
-	      //==================================================================
-        theOutputStreams.resize(0);
+          //for(const auto& econtit : econtdata){
+          for (uint32_t ietd = 0; ietd < econtdata.size(); ietd++) {
+            if (econtdata.at(ietd).first != moduleId)
+              continue;  //Need to assume that order of econtdata and tcprocdata entries is the same.
+            trdata = econtdata.at(ietd).second;
+            tcpdata = tcprocdata.at(ietd).second;
+            std::cout << "=======================TC processor data===================" << std::endl;
+            std::cout << moduleId << std::endl;
+            //tcpdata.print(3);
 
-        theOutputStreams.push_back(updata);//Always a single UnpackerOutputStreamPair, vector only for generality
+            triggerCellsFromTriggerData = createTCsFromTriggerData(moduleId, tcpdata);
+            //std::cout << "Dataloop:: event: " << event << ", moduleId : " << econtdata.at(ietd).first << " moduleId from tcproc data "<<tcprocdata.at(ietd).first << std::endl;
+            for (int ibx = 0; ibx < 7; ibx++) {
+              //for(int ibx=3;ibx<4;ibx++){
+              const uint32_t *el = trdata.getElinks(ibx);
+              uint32_t bx_2 = (el[0] >> 28) & 0xF;
+              if (ilink == 0)
+                TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, econTPar[moduleId].getNofTCs(), el, vTCel);
+              if (ilink == 1)
+                TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, econTPar[moduleId].getNofSTCs(), el, vTCel);
+              if (ilink == 2 or ilink == 3)
+                TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, econTPar[moduleId].getNofSTCs(), el, vTCel);
+              trdata.getUnpkStream(ibx, updata);
+              updata.setModuleId(moduleId);
+              //==================================================================
+              //TC proc emulation something similar to below
+              //==================================================================
+              //TPGStage1Emulation::Stage1IO::convertUnpackerOutputStreamPairToTCProc(bx_2, updata, tcprocemul);
+              //==================================================================
+              //std::cout << "========== ibx : " << ibx << " ==========" << std::endl;
+              //std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
+              //updata.print();
+              //==================================================================
+              //TC proc emulation comparison with data something similar to below
+              //==================================================================
+              theOutputStreams.resize(0);
 
-        //Convert unpacker output to standalone HGCal trigger cells
-        theTCsFromOS.resize(0);
-        theTCsFromOS = convertOSPToTCs(theOutputStreams);
+              theOutputStreams.push_back(updata);  //Always a single UnpackerOutputStreamPair, vector only for generality
 
+              //Convert unpacker output to standalone HGCal trigger cells
+              theTCsFromOS.resize(0);
+              theTCsFromOS = convertOSPToTCs(theOutputStreams);
 
-        //Run TC processor emulator
-        tcs_out_SA.resize(0);
-        unsigned error_code = theAlgo_.run(theTCsFromOS, theConfiguration_, tcs_out_SA);
+              //Run TC processor emulator
+              tcs_out_SA.resize(0);
+              unsigned error_code = theAlgo_.run(theTCsFromOS, theConfiguration_, tcs_out_SA);
 
-        tcs_out_tcproc_TB.resize(0);
-        bool isDataTCsAssigned=false;
-        if(triggerCellsFromTriggerData[ibx].size()>0) tcs_out_tcproc_TB=triggerCellsFromTriggerData[ibx]; isDataTCsAssigned = true;
+              tcs_out_tcproc_TB.resize(0);
+              bool isDataTCsAssigned = false;
+              if (triggerCellsFromTriggerData[ibx].size() > 0)
+                tcs_out_tcproc_TB = triggerCellsFromTriggerData[ibx];
+              isDataTCsAssigned = true;
 
+              if (isDataTCsAssigned) {  //Only try to do comparison if we have read out TB data since some modules are missing
+                bool diffTCs = hasDifferentTCs(tcs_out_SA, tcs_out_tcproc_TB);
 
-            
-        if(isDataTCsAssigned){//Only try to do comparison if we have read out TB data since some modules are missing
-          bool diffTCs=hasDifferentTCs(tcs_out_SA,tcs_out_tcproc_TB);
+                if (diffTCs) {
+                  std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
+                  //vTCel.print();
+                  updata.print();
+                  std::cout << "========== Emulated TC proc results using firmware data of Stage1 unpacker output "
+                               "stream for ibx : "
+                            << ibx << " ==========" << std::endl;
 
-          if(diffTCs){
+                  std::cout << "Printing TCs with column, channel, frame mapping - after TCprocEmul, from ECON-T elink input" << std::endl;
+                  for (auto &tcobj : tcs_out_SA) {
+                    std::cout << "Mod ID " << tcobj.moduleId() << " address " << tcobj.phi() << " energy " << tcobj.energy() << " col " << tcobj.column() << " chn "
+                              << tcobj.channel() << " frame " << tcobj.frame() << std::endl;
+                  }
 
-            std::cout << "========== TPG data: Stage1 unpacker output stream from firmware output for ibx : " << ibx << " ==========" << std::endl;
-	          updata.print();
-            std::cout << "========== Emulated TC proc results using firmware data of Stage1 unpacker output stream for ibx : " << ibx << " ==========" << std::endl;
+                  std::cout << "========== TPG data: TC proc results as read in data link for ibx : " << ibx << " ==========" << std::endl;
 
-            std::cout<<"Printing TCs with column, channel, frame mapping - after TCprocEmul, from ECON-T elink input"<<std::endl;
-            for (auto& tcobj : tcs_out_SA){
-              std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
-            }
+                  std::cout << "Printing TCs with column, channel, frame mapping - as read out from TB data" << std::endl;
+                  for (auto &tcobj : tcs_out_tcproc_TB) {
+                    std::cout << "Mod ID " << tcobj.moduleId() << " address " << tcobj.phi() << " energy " << tcobj.energy() << " col " << tcobj.column() << " chn "
+                              << tcobj.channel() << " frame " << tcobj.frame() << std::endl;
+                  }
 
-	          std::cout << "========== TPG data: TC proc results as read in data link for ibx : " << ibx << " ==========" << std::endl;
+                  std::cout << "========== end of TPG data for ibx : " << ibx << " ==========" << std::endl;
+                }
+                FillHistogram(dir_diff, tcs_out_SA, tcs_out_tcproc_TB);
+              }
+              //tcprocemul.print();
+              //trdata.getTCData(ibx,tcprocdata);
+              //tcprocdata.print();
+              //==================================================================
+            }  //bx loop
+            //if(eventCondn) trdata.print();
+          }  //loop over econt data for a given run
 
-            std::cout<<"Printing TCs with column, channel, frame mapping - as read out from TB data"<<std::endl;
-            for (auto& tcobj : tcs_out_tcproc_TB){
-              std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
-            }
+        }  //econt loop
+      }    //link loop
+    }      //this is essencially event loop
 
-            std::cout << "========== end of TPG data for ibx : " << ibx << " ==========" << std::endl;
-          }
-          FillHistogram(dir_diff,tcs_out_SA,tcs_out_tcproc_TB);
-        }
-	      //tcprocemul.print();
-	      //trdata.getTCData(ibx,tcprocdata);
-	      //tcprocdata.print();
-	      //==================================================================
-	    }//bx loop
-	    //if(eventCondn) trdata.print();
-	  }//loop over econt data for a given run
-
-	}//econt loop
-      }//link loop
-    }//this is essencially event loop
-    
-  }//ieloop
+  }  //ieloop
 
   fout->cd();
   dir_diff->Write();
   fout->Close();
   delete fout;
-  
+
   return true;
 }
 
-uint64_t getTotalNofEvents(uint32_t relayNumber, uint32_t runNumber){
-
+uint64_t getTotalNofEvents(uint32_t relayNumber, uint32_t runNumber) {
   uint64_t nEvents(0);
   //Create the file reader
   Hgcal10gLinkReceiver::FileReader fReader;
-  
+
   //Make the buffer space for the records
   Hgcal10gLinkReceiver::RecordT<4095> *r(new Hgcal10gLinkReceiver::RecordT<4095>);
-  
 
   //Set up specific records to interpet the formats
-  const Hgcal10gLinkReceiver::RecordStarting *rStart((Hgcal10gLinkReceiver::RecordStarting*)r);
-  const Hgcal10gLinkReceiver::RecordStopping *rStop ((Hgcal10gLinkReceiver::RecordStopping*)r);
-  const Hgcal10gLinkReceiver::RecordRunning  *rEvent((Hgcal10gLinkReceiver::RecordRunning*) r);
-  fReader.setDirectory(std::string("dat/Relay")+std::to_string(relayNumber));
+  const Hgcal10gLinkReceiver::RecordStarting *rStart((Hgcal10gLinkReceiver::RecordStarting *)r);
+  const Hgcal10gLinkReceiver::RecordStopping *rStop((Hgcal10gLinkReceiver::RecordStopping *)r);
+  const Hgcal10gLinkReceiver::RecordRunning *rEvent((Hgcal10gLinkReceiver::RecordRunning *)r);
+  fReader.setDirectory(std::string("dat/Relay") + std::to_string(relayNumber));
   //fReader.openRun(runNumber,linkNumber);
   //We open linkNumber=0 which contains trigger data
-  fReader.openRun(runNumber,0); 
-  
+  fReader.openRun(runNumber, 0);
 
-  while(fReader.read(r)) {
+  while (fReader.read(r)) {
     //Check the state of the record and print the record accordingly
-    if( r->state()==Hgcal10gLinkReceiver::FsmState::Starting){
-      if(!(rStart->valid())){
-  	std::cerr << " FsmState::Starting validadity fails : rStart->valid() " << rStart->valid() << std::endl;
-  	rStart->print();
-  	std::cout << std::endl;
-	continue;
+    if (r->state() == Hgcal10gLinkReceiver::FsmState::Starting) {
+      if (!(rStart->valid())) {
+        std::cerr << " FsmState::Starting validadity fails : rStart->valid() " << rStart->valid() << std::endl;
+        rStart->print();
+        std::cout << std::endl;
+        continue;
       }
     }
-    
-    else if(r->state()==Hgcal10gLinkReceiver::FsmState::Stopping){
-      if(!(rStop->valid())){
-  	std::cerr << " FsmState::Stopping validadity fails : rStop->valid() " << rStop->valid() << std::endl;
-  	rStop->print();
-  	std::cout << std::endl;
-	continue;
+
+    else if (r->state() == Hgcal10gLinkReceiver::FsmState::Stopping) {
+      if (!(rStop->valid())) {
+        std::cerr << " FsmState::Stopping validadity fails : rStop->valid() " << rStop->valid() << std::endl;
+        rStop->print();
+        std::cout << std::endl;
+        continue;
       }
     }
-    //Else we have an event record 
-    else{
-      nEvents++;      
-    }//loop event
+    //Else we have an event record
+    else {
+      nEvents++;
+    }  //loop event
   }
-  
+
   std::cout << "========== Total Events : " << nEvents << std::endl;
-  
+
   delete r;
 
   return nEvents;
 }
 
-l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDataformat::UnpackerOutputStreamPair> &upVec){
+l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDataformat::UnpackerOutputStreamPair> &upVec) {
   l1thgcfirmware::HGCalTriggerCellSACollection theTCVec;
-  for (auto& up : upVec){
-      unsigned theModId_ = up.getModuleId();
-      unsigned nChans_ = up.numberOfValidChannels();
-      for (unsigned iChn = 0; iChn < nChans_; iChn++){
-        unsigned nTC=0;
-        unsigned nStream=0;
-        if(nChans_<7){
-            nTC=iChn;
-        } else {
-            nStream = iChn%2;
-            nTC = (iChn-nStream)/2;
-        } 
-        theTCVec.emplace_back(1,1,0,up.channelNumber(nStream,nTC),0,up.channelEnergy(nStream,nTC));
-        theTCVec.back().setModuleId(theModId_);
+  for (auto &up : upVec) {
+    unsigned theModId_ = up.getModuleId();
+    unsigned nChans_ = up.numberOfValidChannels();
+    for (unsigned iChn = 0; iChn < nChans_; iChn++) {
+      unsigned nTC = 0;
+      unsigned nStream = 0;
+      if (nChans_ < 7) {
+        nTC = iChn;
+      } else {
+        nStream = iChn % 2;
+        nTC = (iChn - nStream) / 2;
       }
+      theTCVec.emplace_back(1, 1, 0, up.channelNumber(nStream, nTC), 0, up.channelEnergy(nStream, nTC));
+      theTCVec.back().setModuleId(theModId_);
+    }
   }
   return theTCVec;
 }
 
-bool hasDifferentTCs(l1thgcfirmware::HGCalTriggerCellSACollection tcOrig, l1thgcfirmware::HGCalTriggerCellSACollection tcToComp){
-   if(tcOrig.size()!=tcToComp.size()) return true;
-   for(unsigned i = 0; i<tcOrig.size(); i++){ 
-       if (tcOrig.at(i).energy()!=tcToComp.at(i).energy() || tcOrig.at(i).phi()!=tcToComp.at(i).phi() || tcOrig.at(i).channel()!=tcToComp.at(i).channel() || tcOrig.at(i).frame()!=tcToComp.at(i).frame() || tcOrig.at(i).column()!=tcToComp.at(i).column()){
-	       return true;
-       }
-   }
-   return false;
+bool hasDifferentTCs(l1thgcfirmware::HGCalTriggerCellSACollection tcOrig, l1thgcfirmware::HGCalTriggerCellSACollection tcToComp) {
+  if (tcOrig.size() != tcToComp.size())
+    return true;
+  for (unsigned i = 0; i < tcOrig.size(); i++) {
+    if (tcOrig.at(i).energy() != tcToComp.at(i).energy() || tcOrig.at(i).phi() != tcToComp.at(i).phi() || tcOrig.at(i).channel() != tcToComp.at(i).channel() ||
+        tcOrig.at(i).frame() != tcToComp.at(i).frame() || tcOrig.at(i).column() != tcToComp.at(i).column()) {
+      return true;
+    }
+  }
+  return false;
 }
 
-std::map<uint32_t,l1thgcfirmware::HGCalTriggerCellSACollection> createTCsFromTriggerData(uint32_t moduleId, TPGBEDataformat::TrigTCProcData tcdata_){//ibx
-    std::map<uint32_t,l1thgcfirmware::HGCalTriggerCellSACollection> theTCsFromTriggerData_;
-    for(int ibx=0;ibx<7;ibx++){
-      l1thgcfirmware::HGCalTriggerCellSACollection tmp_tcs;
-      for(int ibin=0;ibin<9;ibin++){
-        for(int iinstance=0;iinstance<2;iinstance++){
-          int tcoutputword = tcdata_.getUnpkWord(ibx,ibin,iinstance);
-          if(tcoutputword > -1){
-            uint32_t tcout_energy = tcoutputword&0x1FF;
-            uint32_t tcout_channel = (tcoutputword>>9)&0x3F;
-            tmp_tcs.emplace_back(1,1,0,tcout_channel,0,tcout_energy);
-            tmp_tcs.back().setColumn(ibin);
-            tmp_tcs.back().setChannel(0);
-            tmp_tcs.back().setFrame(0);
-            tmp_tcs.back().setModuleId(moduleId);
-          }
+std::map<uint32_t, l1thgcfirmware::HGCalTriggerCellSACollection> createTCsFromTriggerData(uint32_t moduleId, TPGBEDataformat::TrigTCProcData tcdata_) {  //ibx
+  std::map<uint32_t, l1thgcfirmware::HGCalTriggerCellSACollection> theTCsFromTriggerData_;
+  for (int ibx = 0; ibx < 7; ibx++) {
+    l1thgcfirmware::HGCalTriggerCellSACollection tmp_tcs;
+    for (int ibin = 0; ibin < 9; ibin++) {
+      for (int iinstance = 0; iinstance < 2; iinstance++) {
+        int tcoutputword = tcdata_.getUnpkWord(ibx, ibin, iinstance);
+        if (tcoutputword > -1) {
+          uint32_t tcout_energy = tcoutputword & 0x1FF;
+          uint32_t tcout_channel = (tcoutputword >> 9) & 0x3F;
+          tmp_tcs.emplace_back(1, 1, 0, tcout_channel, 0, tcout_energy);
+          tmp_tcs.back().setColumn(ibin);
+          tmp_tcs.back().setChannel(0);
+          tmp_tcs.back().setFrame(0);
+          tmp_tcs.back().setModuleId(moduleId);
         }
       }
-      theTCsFromTriggerData_[ibx]=tmp_tcs;
     }
+    theTCsFromTriggerData_[ibx] = tmp_tcs;
+  }
   return theTCsFromTriggerData_;
 }
 
-void BookHistograms(TDirectory*& dir_diff, uint32_t relay){
-  TH1D *hTCProcDiff_nonzero_size = new TH1D("hTCProcDiff_nonzero_size", Form("TC processor difference in output size if both TC lists are nonzero in length for Relay: %u", relay),51,-25.5,25.5);
+void BookHistograms(TDirectory *&dir_diff, uint32_t relay) {
+  TH1D *hTCProcDiff_nonzero_size =
+      new TH1D("hTCProcDiff_nonzero_size", Form("TC processor difference in output size if both TC lists are nonzero in length for Relay: %u", relay), 51, -25.5, 25.5);
   hTCProcDiff_nonzero_size->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator (nonzero TC list length)");
   hTCProcDiff_nonzero_size->GetYaxis()->SetTitle("Entries");
   hTCProcDiff_nonzero_size->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff_size = new TH1D("hTCProcDiff_size", Form("TC processor difference in output size for Relay: %u", relay),51,-25.5,25.5);
+  TH1D *hTCProcDiff_size = new TH1D("hTCProcDiff_size", Form("TC processor difference in output size for Relay: %u", relay), 51, -25.5, 25.5);
   hTCProcDiff_size->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator");
   hTCProcDiff_size->GetYaxis()->SetTitle("Entries");
   hTCProcDiff_size->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff_quantities = new TH1D("hTCProcDiff_quantities", Form("TC processor difference in output quantities for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff_quantities = new TH1D("hTCProcDiff_quantities", Form("TC processor difference in output quantities for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator");
   hTCProcDiff_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff256_quantities = new TH1D("hTCProcDiff256_quantities", Form("TC processor difference in output quantities mod 256 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff256_quantities = new TH1D("hTCProcDiff256_quantities", Form("TC processor difference in output quantities mod 256 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff256_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 256");
   hTCProcDiff256_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff256_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff768_quantities = new TH1D("hTCProcDiff768_quantities", Form("TC processor difference in output quantities mod 768 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff768_quantities = new TH1D("hTCProcDiff768_quantities", Form("TC processor difference in output quantities mod 768 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff768_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 768");
   hTCProcDiff768_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff768_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff1280_quantities = new TH1D("hTCProcDiff1280_quantities", Form("TC processor difference in output quantities mod 1280 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff1280_quantities = new TH1D("hTCProcDiff1280_quantities", Form("TC processor difference in output quantities mod 1280 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff1280_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 1280");
   hTCProcDiff1280_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff1280_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff8448_quantities = new TH1D("hTCProcDiff8448_quantities", Form("TC processor difference in output quantities mod 8448 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff8448_quantities = new TH1D("hTCProcDiff8448_quantities", Form("TC processor difference in output quantities mod 8448 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff8448_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 8448");
   hTCProcDiff8448_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff8448_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff8960_quantities = new TH1D("hTCProcDiff8960_quantities", Form("TC processor difference in output quantities mod 8960 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff8960_quantities = new TH1D("hTCProcDiff8960_quantities", Form("TC processor difference in output quantities mod 8960 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff8960_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 8960");
   hTCProcDiff8960_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff8960_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff9472_quantities = new TH1D("hTCProcDiff9472_quantities", Form("TC processor difference in output quantities mod 9472 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff9472_quantities = new TH1D("hTCProcDiff9472_quantities", Form("TC processor difference in output quantities mod 9472 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff9472_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 9472");
   hTCProcDiff9472_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff9472_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff16640_quantities = new TH1D("hTCProcDiff16640_quantities", Form("TC processor difference in output quantities mod 16640 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff16640_quantities = new TH1D("hTCProcDiff16640_quantities", Form("TC processor difference in output quantities mod 16640 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff16640_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 16640");
   hTCProcDiff16640_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff16640_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff17152_quantities = new TH1D("hTCProcDiff17152_quantities", Form("TC processor difference in output quantities mod 17152 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff17152_quantities = new TH1D("hTCProcDiff17152_quantities", Form("TC processor difference in output quantities mod 17152 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff17152_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 17152");
   hTCProcDiff17152_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff17152_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff24832_quantities = new TH1D("hTCProcDiff24832_quantities", Form("TC processor difference in output quantities mod 24832 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff24832_quantities = new TH1D("hTCProcDiff24832_quantities", Form("TC processor difference in output quantities mod 24832 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff24832_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 24832");
   hTCProcDiff24832_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff24832_quantities->SetDirectory(dir_diff);
 
-  TH1D *hTCProcDiff25344_quantities = new TH1D("hTCProcDiff25344_quantities", Form("TC processor difference in output quantities mod 25344 for Relay: %u", relay),52,-0.5,25.5);
+  TH1D *hTCProcDiff25344_quantities = new TH1D("hTCProcDiff25344_quantities", Form("TC processor difference in output quantities mod 25344 for Relay: %u", relay), 52, -0.5, 25.5);
   hTCProcDiff25344_quantities->GetXaxis()->SetTitle("Difference between firmware TC processor and emulator in module 25344");
   hTCProcDiff25344_quantities->GetYaxis()->SetTitle("Entries");
   hTCProcDiff25344_quantities->SetDirectory(dir_diff);
-
 }
 
-void FillHistogram(TDirectory*& dir_diff, l1thgcfirmware::HGCalTriggerCellSACollection tcProcEmulator, l1thgcfirmware::HGCalTriggerCellSACollection tcProcTB){
-    TList *list = (TList *)dir_diff->GetList();
+void FillHistogram(TDirectory *&dir_diff, l1thgcfirmware::HGCalTriggerCellSACollection tcProcEmulator, l1thgcfirmware::HGCalTriggerCellSACollection tcProcTB) {
+  TList *list = (TList *)dir_diff->GetList();
 
-    int theTCListSizeDiff = tcProcEmulator.size()-tcProcTB.size();
-    if (tcProcEmulator.size()>0 && tcProcTB.size()>0){
-      int theTCListNonzeroSizeDiff = tcProcEmulator.size()-tcProcTB.size();
-      ((TH1D *) list->FindObject("hTCProcDiff_nonzero_size"))->Fill(theTCListNonzeroSizeDiff);
-    }
-    ((TH1D *) list->FindObject("hTCProcDiff_size"))->Fill(theTCListSizeDiff);
-    unsigned theSizeToTest = std::min(tcProcEmulator.size(),tcProcTB.size());
-    unsigned theModuleId = 0;
-    if(theSizeToTest>0) theModuleId = tcProcEmulator.at(0).moduleId();
-    for(unsigned i=0; i<theSizeToTest; i++){
-      unsigned diffsize = std::abs(int(tcProcEmulator.at(i).energy()-tcProcTB.at(i).energy()))+std::abs(int(tcProcEmulator.at(i).phi()-tcProcTB.at(i).phi()))+std::abs(int(tcProcEmulator.at(i).channel()-tcProcTB.at(i).channel()))+std::abs(int(tcProcEmulator.at(i).frame()-tcProcTB.at(i).frame()))+std::abs(int(tcProcEmulator.at(i).column()-tcProcTB.at(i).column()));
-      ((TH1D *) list->FindObject("hTCProcDiff_quantities"))->Fill(diffsize);
-      if(theModuleId==256) ((TH1D *) list->FindObject("hTCProcDiff256_quantities"))->Fill(diffsize);
-      else if(theModuleId==768) ((TH1D *) list->FindObject("hTCProcDiff768_quantities"))->Fill(diffsize);
-      else if(theModuleId==1280) ((TH1D *) list->FindObject("hTCProcDiff1280_quantities"))->Fill(diffsize);
-      else if(theModuleId==8448) ((TH1D *) list->FindObject("hTCProcDiff8448_quantities"))->Fill(diffsize);
-      else if(theModuleId==8960) ((TH1D *) list->FindObject("hTCProcDiff8960_quantities"))->Fill(diffsize);
-      else if(theModuleId==9472) ((TH1D *) list->FindObject("hTCProcDiff9472_quantities"))->Fill(diffsize);
-      else if(theModuleId==16640) ((TH1D *) list->FindObject("hTCProcDiff16640_quantities"))->Fill(diffsize);
-      else if(theModuleId==17152) ((TH1D *) list->FindObject("hTCProcDiff17152_quantities"))->Fill(diffsize);
-      else if(theModuleId==24832) ((TH1D *) list->FindObject("hTCProcDiff24832_quantities"))->Fill(diffsize);
-      else if(theModuleId==25344) ((TH1D *) list->FindObject("hTCProcDiff25344_quantities"))->Fill(diffsize);
-    }
+  int theTCListSizeDiff = tcProcEmulator.size() - tcProcTB.size();
+  if (tcProcEmulator.size() > 0 && tcProcTB.size() > 0) {
+    int theTCListNonzeroSizeDiff = tcProcEmulator.size() - tcProcTB.size();
+    ((TH1D *)list->FindObject("hTCProcDiff_nonzero_size"))->Fill(theTCListNonzeroSizeDiff);
+  }
+  ((TH1D *)list->FindObject("hTCProcDiff_size"))->Fill(theTCListSizeDiff);
+  unsigned theSizeToTest = std::min(tcProcEmulator.size(), tcProcTB.size());
+  unsigned theModuleId = 0;
+  if (theSizeToTest > 0)
+    theModuleId = tcProcEmulator.at(0).moduleId();
+  for (unsigned i = 0; i < theSizeToTest; i++) {
+    unsigned diffsize = std::abs(int(tcProcEmulator.at(i).energy() - tcProcTB.at(i).energy())) + std::abs(int(tcProcEmulator.at(i).phi() - tcProcTB.at(i).phi())) +
+                        std::abs(int(tcProcEmulator.at(i).channel() - tcProcTB.at(i).channel())) + std::abs(int(tcProcEmulator.at(i).frame() - tcProcTB.at(i).frame())) +
+                        std::abs(int(tcProcEmulator.at(i).column() - tcProcTB.at(i).column()));
+    ((TH1D *)list->FindObject("hTCProcDiff_quantities"))->Fill(diffsize);
+    if (theModuleId == 256)
+      ((TH1D *)list->FindObject("hTCProcDiff256_quantities"))->Fill(diffsize);
+    else if (theModuleId == 768)
+      ((TH1D *)list->FindObject("hTCProcDiff768_quantities"))->Fill(diffsize);
+    else if (theModuleId == 1280)
+      ((TH1D *)list->FindObject("hTCProcDiff1280_quantities"))->Fill(diffsize);
+    else if (theModuleId == 8448)
+      ((TH1D *)list->FindObject("hTCProcDiff8448_quantities"))->Fill(diffsize);
+    else if (theModuleId == 8960)
+      ((TH1D *)list->FindObject("hTCProcDiff8960_quantities"))->Fill(diffsize);
+    else if (theModuleId == 9472)
+      ((TH1D *)list->FindObject("hTCProcDiff9472_quantities"))->Fill(diffsize);
+    else if (theModuleId == 16640)
+      ((TH1D *)list->FindObject("hTCProcDiff16640_quantities"))->Fill(diffsize);
+    else if (theModuleId == 17152)
+      ((TH1D *)list->FindObject("hTCProcDiff17152_quantities"))->Fill(diffsize);
+    else if (theModuleId == 24832)
+      ((TH1D *)list->FindObject("hTCProcDiff24832_quantities"))->Fill(diffsize);
+    else if (theModuleId == 25344)
+      ((TH1D *)list->FindObject("hTCProcDiff25344_quantities"))->Fill(diffsize);
+  }
 }

--- a/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
+++ b/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
@@ -208,6 +208,7 @@ int main(int argc, char** argv)
   //===============================================================================================================================
   l1thgcfirmware::HGCalLayer1PhiOrderFwConfig theConfiguration_;
   theConfiguration_.configureSeptemberTestBeamMappingInfo();
+  theConfiguration_.configureTDAQReadoutInfo();
 
   //===============================================================================================================================
   //Process certain reference eventlist

--- a/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
+++ b/test-beam_Sep24_macros/tpgdata_3T_tcproc.cpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  Created on : 18/10/2024
  Purpose    : Example to read TPG data for TC processor
- Author     : Indranil Das, Research Associate, Imperial
- Email      : indranil.das@cern.ch | indra.ehep@gmail.com
+ Author     : Indranil Das, Research Associate, Imperial (TPG data reading framework) / Adinda de Wit (TC processor emulation)
+ Email      : indranil.das@cern.ch | indra.ehep@gmail.com / adinda.dewit@cern.ch
 **********************************************************************/
 #include <iostream>
 


### PR DESCRIPTION
Adds comparisons between TC processor data as read out during the September test beam and the TC processor emulator.

Emulates first the TC processor configuration, then the TDAQ readout (which cannot read all the TCs), in two steps.