### PR TITLE
Cluster properties - fix a few properties

### DIFF
--- a/TPGStage2Emulation/Stage2.hh
+++ b/TPGStage2Emulation/Stage2.hh
@@ -42,8 +42,9 @@ namespace TPGStage2Emulation
     unsigned int getTriggerLayer(const unsigned layer) const {
       bool cee(layer<=26);
       unsigned triggerLayer = 0;
-      if (cee) triggerLayer = layer/2;
-      else triggerLayer = layer-13;
+      if (cee) triggerLayer = layer/2+1;
+      else triggerLayer = layer-13+1;
+
       return triggerLayer;
     }
 

--- a/test-stage2_Nov24/testStage2SemiClustering.cpp
+++ b/test-stage2_Nov24/testStage2SemiClustering.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv)
   clusterTree->Branch("clusEta_CMSSW", &clusterEta_CMSSW);
   clusterTree->Branch("clusPhi_CMSSW", &clusterPhi_CMSSW);
   clusterTree->Branch("clusZ_CMSSW", &clusterZ_CMSSW);
-  clusterTree->Branch("clusFracInCEE_CMSSW", &clusterFracInCoreCEE_CMSSW);
+  clusterTree->Branch("clusFracInCEE_CMSSW", &clusterFracInCEE_CMSSW);
   clusterTree->Branch("clusFracInCoreCEE_CMSSW", &clusterFracInCoreCEE_CMSSW);
   clusterTree->Branch("clusFracInEarlyCEH_CMSSW", &clusterFracInEarlyCEH_CMSSW);
   clusterTree->Branch("clusFirstLayer_CMSSW", &clusterFirstLayer_CMSSW);

--- a/test-stage2_Nov24/testStage2SemiClustering.cpp
+++ b/test-stage2_Nov24/testStage2SemiClustering.cpp
@@ -345,6 +345,7 @@ int main(int argc, char** argv)
           rotatedPhi = M_PI - rotatedPhi;
         }
         rotatedPhi -= (rotatedPhi > M_PI) ? 2 * M_PI : 0;
+        rotatedPhi += (rotatedPhi < -1.0*M_PI) ? 2 * M_PI : 0;
 
         clusterPhi_CMSSW.push_back(rotatedPhi);
         clusterZ_CMSSW.push_back(l1thgcfirmware::Scales::floatZ(hwCluster.w_z));


### PR DESCRIPTION
Building on #41, fix a few of the properties, as noted by Paul:

- trigger layer based variables have values between 1-34, rather than 0-33
- in my previous plots, FracInCEE was duplicating FracInCoreCEE, now fixed

Also fixed cases where phi was < -pi during the conversion from local to global phi.

Update plots just plotting the raw cluster properties distributions below.  FracInCee is now peaked at 1, phi doesn't extend below -pi.

I just noticed there are never any cluster with First/LastLayer of 14 and 16.  To be investigated.

![image](https://github.com/user-attachments/assets/39ea1e98-7705-4961-b725-3fec9892e315)

This PR can be merged now.
