### PR TITLE
Fix bug, calcPhi should return signed int.

### DIFF
--- a/TPGStage2Emulation/Stage2.hh
+++ b/TPGStage2Emulation/Stage2.hh
@@ -136,7 +136,7 @@ namespace TPGStage2Emulation
 
     uint64_t layerBits() const { return layerBits_; }
 
-    unsigned int calcPhi() const
+    int calcPhi() const
     {
       return atan2( avgY(), avgX()) * 720 / acos(-1.0);
     }


### PR DESCRIPTION
Bug spotted by Paul, introduced in #38 when I put phi calculation into it's own function.