### PR TITLE
Integrate mapping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "mapping"]
 	path = mapping
 	url = ssh://git@gitlab.cern.ch:7999/hgcal-tpg/mapping.git
+	branch = cppInterface

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "EMPTools/HLS_arbitrary_Precision_Types"]
 	path = EMPTools/HLS_arbitrary_Precision_Types
 	url = https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git
+[submodule "mapping"]
+	path = mapping
+	url = ssh://git@gitlab.cern.ch:7999/hgcal-tpg/mapping.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 LDFLAGS=-L$(HOME)/Software/yaml-cpp/lib64
 CPPFLAGS=-I$(HOME)/Software/yaml-cpp/include -I common/inc -I inc -I TPGStage1Emulation/ -I TPGFEEmulation/ -I`root-config --incdir` 
 
-all:  findFixedpattern.exe findEMax.exe tpgdata_3T_tcproc.exe  tpgdata_3T_fe.exe  scanadc_Sep24.exe dump_event.exe tpgdata_2T_fe.exe emul_Sep24.exe emul_3T_Sep24.exe TestEMP #loop_emul_Sep24.exe scanconfigval_Sep24.exe emul_Sep24.exe validateFixedADC.exe # findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
+all:  findFixedpattern.exe findEMax.exe tpgdata_3T_tcproc.exe  tpgdata_3T_fe.exe  scanadc_Sep24.exe dump_event.exe tpgdata_2T_fe.exe emul_Sep24.exe emul_3T_Sep24.exe TestEMP testMapping #loop_emul_Sep24.exe scanconfigval_Sep24.exe emul_Sep24.exe validateFixedADC.exe # findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
 
 emul_test-beam_Sep23.exe:  test-beam_Sep23_macros/emul_test-beam_Sep23.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep23_macros/emul_test-beam_Sep23.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_test-beam_Sep23.exe
@@ -60,6 +60,11 @@ TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.
 
 TestEMP: EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* $(CONDA_PREFIX)/include
 	g++  EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(CONDA_PREFIX)/include -lboost_iostreams -lz -llzma -o TestEMP.exe
+
+testMapping: test-mapping/test.cpp  mapping/c++/HgcConfigReader2.*
+	g++ test-mapping/test.cpp mapping/c++/HgcConfigReader2.Xml.cpp -Imapping/c++/ -o testMapping.exe
+
+
 
 clean:
 	rm *.exe

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 LDFLAGS=-L$(HOME)/Software/yaml-cpp/lib64
 CPPFLAGS=-I$(HOME)/Software/yaml-cpp/include -I common/inc -I inc -I TPGStage1Emulation/ -I TPGFEEmulation/ -I`root-config --incdir` 
 
-all:  findFixedpattern.exe findEMax.exe tpgdata_3T_tcproc.exe  tpgdata_3T_fe.exe  scanadc_Sep24.exe dump_event.exe tpgdata_2T_fe.exe emul_Sep24.exe emul_3T_Sep24.exe TestEMP testMapping #loop_emul_Sep24.exe scanconfigval_Sep24.exe emul_Sep24.exe validateFixedADC.exe # findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
+all:  findFixedpattern.exe findEMax.exe tpgdata_3T_tcproc.exe  tpgdata_3T_fe.exe  scanadc_Sep24.exe dump_event.exe tpgdata_2T_fe.exe emul_Sep24.exe emul_3T_Sep24.exe testEMP testMapping #loop_emul_Sep24.exe scanconfigval_Sep24.exe emul_Sep24.exe validateFixedADC.exe # findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
 
 emul_test-beam_Sep23.exe:  test-beam_Sep23_macros/emul_test-beam_Sep23.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS) test-beam_Sep23_macros/emul_test-beam_Sep23.cpp  -l yaml-cpp `root-config --libs --cflags` -o emul_test-beam_Sep23.exe
@@ -58,8 +58,8 @@ GenerateEmpRxFile.exe: TPGStage1Emulation/GenerateEmpRxFile.cpp inc/*.*  TPGFEEm
 TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.cpp TPGFEEmulation/*.hh *.h TPGStage1Emulation/*.hh common/inc/*.h
 	g++ -I TPGStage1Emulation/ -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc -I. -I common/inc -I inc -I TPGFEEmulation/ TPGStage1Emulation/TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o TestUnpackerTCProcInterface.exe
 
-TestEMP: EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* $(CONDA_PREFIX)/include
-	g++  EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(CONDA_PREFIX)/include -lboost_iostreams -lz -llzma -o TestEMP.exe
+testEMP: EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* $(CONDA_PREFIX)/include
+	g++  EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(CONDA_PREFIX)/include -lboost_iostreams -lz -llzma -o testEMP.exe
 
 testMapping: test-mapping/test.cpp  mapping/c++/HgcConfigReader2.*
 	g++ test-mapping/test.cpp mapping/c++/HgcConfigReader2.Xml.cpp -Imapping/c++/ -o testMapping.exe

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Run the setup code to download additional dependencies and setup. This setup is 
 
 ## Compile and run
 
+### Examples for accessing mapping and EMP pattern file I/O
+
+This requires additional code from CMSSW and submodules:
+```
+cd EMPTools;
+source getCMSSWCode.sh;
+cd ..;
+git submodule init;
+git submodule update;
+```
+Compile and run the examples:
+```
+make testEMP
+./testEMP.exe
+make testMapping
+./testMapping.exe
+```
+
 ### Test-beam data of August 2024
 To process the test-beam binary files
 ```

--- a/test-mapping/test.cpp
+++ b/test-mapping/test.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+#include "HgcConfigReader2.hpp"
+// #include "GUID.hpp"
+
+int main() {
+
+  // Opening the decoders xml file essentially populates C++ mapping objects with all info we currently need
+  OpenDecoders( "./mapping/scenarios/SeparateTD.120.MixedTypes.PatchPanel_v3/S1.Decoders.xml"  );
+  // However can open subset of xml files if you want e.g. :
+  // OpenRegions("./mapping/scenarios/SeparateTD.120.MixedTypes.PatchPanel_v3/S1.regions.xml");
+  // OpenPatch( "./mapping/patch/Patch.Rotated.xml"  );
+
+  // Prints to screen objects that have been read in, and how many of them there are
+  for ( auto& ptr : printers ) (*ptr)();
+
+  // ==========================================================
+  // Example of extracting modules connected to a S1 FPGA
+  // ==========================================================
+  // Get all S1 boards
+  const auto& S1s = S1::instances;
+  std::cout << "Total number of S1s : " << S1s.size() << std::endl;
+  // Get the "first" S1 board
+  const auto testS1 = S1s.begin()->second;
+  // Get all modules by going via regions->motherboards->modules
+  std::set<const Module*> modules;
+  for (const auto& region : testS1->regions) {
+      for (const auto& motherboard : region->motherboards) {
+          for (const auto& module : motherboard->modules) {
+              modules.insert(module);
+          }
+      }
+  }
+  // Print to screen IDs of modules (just first ten)
+  unsigned iModule = 0;
+  for ( const auto& module : modules ) {
+    std::cout << module->ID << std::endl;
+    ++iModule;
+    if ( iModule > 10 ) {
+      std::cout << "... and many more ..." << std::endl;
+      break;
+    }
+  }
+
+  // ==========================================================
+  // Example of checking consistency of mapping
+  // ==========================================================
+  bool allOK = true;
+  // Loop all S1 FPGAS
+  for (const auto& [id, s1] : S1s) {
+      // For each S1 FPGA, can get connected modules via regions->motherboards->modules
+      // and decoders->motherboards->modules
+      // Collect both and compare
+
+      // Collect via Regions
+      std::set<const Module*> modulesViaRegions;
+      for (const auto& region : s1->regions) {
+          for (const auto& motherboard : region->motherboards) {
+              for (const auto& module : motherboard->modules) {
+                  modulesViaRegions.insert(module);
+              }
+          }
+      }
+
+      // Collect modules via Decoders
+      std::set<const Module*> modulesViaDecoders;
+      for (const auto& decoder : s1->decoders) {
+          for (const auto& motherboard : decoder->motherboards) {
+              for (const auto& module : motherboard->modules) {
+                  modulesViaDecoders.insert(module);
+              }
+          }
+      }
+      // Compare the sets
+      if (modulesViaRegions != modulesViaDecoders) {
+          std::cout << "  The modules are different between the two paths." << std::endl;
+          allOK = false;
+          break;
+      }
+  }
+  if ( allOK ) {
+      std::cout << "All comparisons were fine" << std::endl;
+  }
+}


### PR DESCRIPTION
This PR introduces Andy's mapping repository as a submodule, and provides an example of how to access the mapping info.

I am not using the main branch of the mapping repository, as there are changes required to make the C++ interface compatible with the latest xml mapping files, which are introduced in the [cppInterface branch](https://gitlab.cern.ch/hgcal-tpg/mapping/-/merge_requests/2).

At the moment, I can get e.g. which modules will send data to a particular Stage 1 FPGA (as shown in the example) and their IDs as defined by Andy, however I don't yet understand how to extract information from the ID e.g. the module u, v, and layer.