### PR TITLE
Further examples for accessing mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.
 testEMP: EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* $(CONDA_PREFIX)/include
 	g++  EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(CONDA_PREFIX)/include -lboost_iostreams -lz -llzma -o testEMP.exe
 
-testMapping: test-mapping/test.cpp  mapping/c++/HgcConfigReader2.*
+testMapping: test-mapping/test.cpp  mapping/c++/HgcConfigReader2.* mapping/c++/GUID.hpp
 	g++ test-mapping/test.cpp mapping/c++/HgcConfigReader2.Xml.cpp -Imapping/c++/ -o testMapping.exe
 
 

--- a/test-mapping/test.cpp
+++ b/test-mapping/test.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include "HgcConfigReader2.hpp"
-// #include "GUID.hpp"
+#include "GUID.hpp"
 
 int main() {
 
@@ -32,8 +32,12 @@ int main() {
   }
   // Print to screen IDs of modules (just first ten)
   unsigned iModule = 0;
+  std::cout << "Module (ID, u, v, layer) : " << std ::endl;
   for ( const auto& module : modules ) {
-    std::cout << module->ID << std::endl;
+    const auto& moduleUV = get_module_uv( module->ID );
+    const auto modulePlane = get_plane( module->ID );
+    std::cout << module->ID << " " << moduleUV.first << " " << moduleUV.second << " " << modulePlane << std::endl;
+
     ++iModule;
     if ( iModule > 10 ) {
       std::cout << "... and many more ..." << std::endl;

--- a/test-mapping/test.cpp
+++ b/test-mapping/test.cpp
@@ -80,4 +80,36 @@ int main() {
   if ( allOK ) {
       std::cout << "All comparisons were fine" << std::endl;
   }
+
+  // ==========================================================
+  // Example exploring output from a S1 FPGA
+  // ==========================================================
+  // Using same "first" S1 board as before as a test
+  // Get all output channels from this FPGA
+  std::set<S1Channel*> channels;
+  std::cout << "Number of output channels : " << testS1->channels.size() << std::endl;
+  unsigned iChannel = 0;
+  for ( const auto& channel : testS1->channels ) {
+    std::cout << "Channel : " << iChannel << " :  " << channel->ID << std::endl;
+    channels.insert(channel);
+    ++iChannel;
+  }
+
+  // Now look at first channel of this FPGA
+  const auto testChannel = *channels.begin();
+  std::cout << "Number of frames on this channel : " << testChannel->frames.size() << std::endl;
+  unsigned iFrame = 0;
+  for ( const auto& frame : testChannel->frames ) {
+    const auto& frameData = frame->data;
+    // frame->ID : clock within TMUX period
+    // frameData.first : index of the TC within the phi-sorted Motherboard/Module 
+    // frameData.second : module ID
+    std::cout << "Frame info : " << frame->ID << " " << frameData.first << " " << frameData.second << std::endl;
+
+    ++iFrame;
+    if ( iFrame > 10 ) {
+      std::cout << "... and many more ..." << std::endl;
+      break;
+    }
+  }
 }


### PR DESCRIPTION
- Example to access info at output of S1
- Example to extract info from module ID

This can be merged now.  I will continue with adding the S2 processing column to the info available for the output of S1, and also the nTCs/module type as well.