### PR TITLE
Add module and S2 column info

### DIFF
--- a/test-mapping/test.cpp
+++ b/test-mapping/test.cpp
@@ -32,11 +32,11 @@ int main() {
   }
   // Print to screen IDs of modules (just first ten)
   unsigned iModule = 0;
-  std::cout << "Module (ID, u, v, layer) : " << std ::endl;
+  std::cout << "Module (ID, u, v, layer, nTC, highOccupancy) : " << std ::endl;
   for ( const auto& module : modules ) {
     const auto& moduleUV = get_module_uv( module->ID );
     const auto modulePlane = get_plane( module->ID );
-    std::cout << module->ID << " " << moduleUV.first << " " << moduleUV.second << " " << modulePlane << std::endl;
+    std::cout << module->ID << " " << moduleUV.first << " " << moduleUV.second << " " << modulePlane << " " << module->data.tcCount << " " << module->data.highOccupancy << std::endl;
 
     ++iModule;
     if ( iModule > 10 ) {

--- a/test-mapping/test.cpp
+++ b/test-mapping/test.cpp
@@ -106,9 +106,10 @@ int main() {
   for ( const auto& frame : testChannel->frames ) {
     const auto& frameData = frame->data;
     // frame->ID : clock within TMUX period
-    // frameData.first : index of the TC within the phi-sorted Motherboard/Module 
-    // frameData.second : module ID
-    std::cout << "Frame info : " << frame->ID << " " << frameData.first << " " << frameData.second << std::endl;
+    // frameData.index : index of the TC within the phi-sorted Motherboard/Module 
+    // frameData.moduleid : module ID
+    // frameData.triCol : S2 processing column
+    std::cout << "Frame info : " << frame->ID << " " << frameData.index << " " << frameData.moduleid << " " << frameData.triCol << std::endl;
 
     ++iFrame;
     if ( iFrame > 10 ) {


### PR DESCRIPTION
I have pushed additional changes to my [PR to the mapping project](https://gitlab.cern.ch/hgcal-tpg/mapping/-/merge_requests/2), adding additional info to the interface structs, namely:

- Module TC count and whether the module is low/high occupancy
- S2 processing column

This PR just adds a few lines to the test/demo script to show how the info is retrieved.

@indra-ehep this can be merged when you are happy with it.

FYI @jbsauvan