### PR TITLE
Adding TC processor emulator running on EMP file from test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #all: emul_test-beam_Sep23 findEMax read_econt_Jul24 GenerateEmpRxFile
 LDFLAGS=-L$(HOME)/Software/yaml-cpp/lib64
 CPPFLAGS=-I$(HOME)/Software/yaml-cpp/include -I common/inc -I inc -I TPGStage1Emulation/ -I TPGFEEmulation/ -I`root-config --incdir` 
+BOOST = /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814
 
 all:  findFixedpattern.exe findEMax.exe tpgdata_3T_tcproc.exe  tpgdata_3T_fe.exe  scanadc_Sep24.exe dump_event.exe tpgdata_2T_fe.exe emul_Sep24.exe emul_3T_Sep24.exe TestEMP #loop_emul_Sep24.exe scanconfigval_Sep24.exe emul_Sep24.exe validateFixedADC.exe # findEMax.exe GenerateEmpRxFile.exe dump_event.exe emul_test-beam_Sep23.exe 
 
@@ -55,8 +56,8 @@ dump_event.exe: test-beam_Sep24_macros/dump_event.cpp inc/*.*  TPGFEEmulation/*.
 GenerateEmpRxFile.exe: TPGStage1Emulation/GenerateEmpRxFile.cpp inc/*.*  TPGFEEmulation/*.hh TPGStage1Emulation/*.hh common/inc/*.h
 	g++ $(LDFLAGS) $(CPPFLAGS)  TPGStage1Emulation/GenerateEmpRxFile.cpp  -l yaml-cpp `root-config --libs --cflags` -o GenerateEmpRxFile.exe
 
-TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.cpp TPGFEEmulation/*.hh *.h TPGStage1Emulation/*.hh common/inc/*.h
-	g++ -I TPGStage1Emulation/ -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc -I. -I common/inc -I inc -I TPGFEEmulation/ TPGStage1Emulation/TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` -o TestUnpackerTCProcInterface.exe
+TestUnpackerTCProcInterface.exe: TPGStage1Emulation/TestUnpackerTCProcInterface.cpp TPGFEEmulation/*.hh *.h TPGStage1Emulation/*.hh common/inc/*.h inc/*.*
+	g++ -I TPGStage1Emulation/ -I. TPGStage1Emulation/HGCalLayer1PhiOrderFwImpl.cc -I. -I common/inc -I inc -I TPGFEEmulation/ TPGStage1Emulation/TestUnpackerTCProcInterface.cpp -L /opt/local/lib  -l yaml-cpp `root-config --libs --cflags` -I`root-config --incdir` EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(BOOST)/include -lboost_iostreams -lz -llzma $(LDFLAGS) $(CPPFLAGS) `root-config --libs --cflags` -o TestUnpackerTCProcInterface.exe
 
 TestEMP: EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* $(CONDA_PREFIX)/include
 	g++  EMPTools/test.cpp EMPTools/CMSSWCode/L1Trigger/DemonstratorTools/src/* -IEMPTools/CMSSWCode/ -IEMPTools/HLS_arbitrary_Precision_Types/include/ -I$(CONDA_PREFIX)/include -lboost_iostreams -lz -llzma -o TestEMP.exe

--- a/TPGStage1Emulation/TestUnpackerTCProcInterface.cpp
+++ b/TPGStage1Emulation/TestUnpackerTCProcInterface.cpp
@@ -16,13 +16,17 @@ g++ -I TPGStage1Emulation -I. HGCalLayer1PhiOrderFwImpl.cc -I. TestUnpackerTCPro
 #include "HGCalTriggerCell_SA.h"
 #include "HGCalLayer1PhiOrderFwImpl.h"
 #include "HGCalLayer1PhiOrderFwConfig.h"
+#include "L1Trigger/DemonstratorTools/interface/utilities.h"
+#include "TPGFEDataformat.hh"
+#include "TPGBEDataformat.hh"
+#include "Stage1IO.hh"
+#include "TFile.h"
+#include "TTree.h"
 
 l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDataformat::UnpackerOutputStreamPair> &upVec){
   l1thgcfirmware::HGCalTriggerCellSACollection theTCVec;
   for (auto& up : upVec){
       unsigned theModId_ = up.getModuleId();
-      //std::cout<<"Module ID "<<theModId_<<std::endl;
-      //std::cout<<"Number of valid channels "<<up.numberOfValidChannels()<<std::endl;
       unsigned nChans_ = up.numberOfValidChannels();
       for (unsigned iChn = 0; iChn < nChans_; iChn++){
         unsigned nTC=0;
@@ -32,12 +36,10 @@ l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDa
         } else {
             nStream = iChn%2;
             nTC = (iChn-nStream)/2;
-            //std::cout<<"for TC in iChn "<<iChn<<" nStream "<<nStream<<" nTC "<<nTC<<std::endl;
         }
         theTCVec.emplace_back(1,1,0,up.channelNumber(nStream,nTC),0,up.unpackedChannelEnergy(nStream,nTC));
         theTCVec.back().setModuleId(theModId_);
 
-        //std::cout<<"number "<<up.channelNumber(nStream,nTC)<<" address "<<up.channelNumber(nStream,nTC)<<" unpacked energy "<<up.unpackedChannelEnergy(nStream,nTC)<<std::endl;
       }
   }
   return theTCVec;
@@ -45,92 +47,110 @@ l1thgcfirmware::HGCalTriggerCellSACollection convertOSPToTCs(std::vector<TPGBEDa
 
 
 
-int main() {
+int main(int argc, char** argv) {
   unsigned total_error_code=0;
-  TPGStage1Emulation::Stage1IOFwCfg fwCfg;
-
-  unsigned ln(0);
-  for(unsigned lp(0);lp<TPGStage1Emulation::Stage1IOFwCfg::MaximumLpgbtPairs;lp++) {
-    bool connected(false);
-    for(unsigned up(0);up<TPGStage1Emulation::Stage1IOFwCfg::MaximumUnpackersPerLpgbtPair;up++) {
-      if(fwCfg.connected(lp,up)) connected=true;
-    }
+  bool doPrint=false; //If turned on (by command line argument), print output to screen. Otherwise only create root file
+  if(argc > 1 && atoi(argv[1])==1){
+      doPrint=true;
   }
-  
-  TPGFEDataformat::TcRawDataPacket vTc;
-  TPGBEDataformat::UnpackerOutputStreamPair theOSP;
-  std::vector<TPGBEDataformat::UnpackerOutputStreamPair> theOutputStreams;
 
-  //The following loop largely copied from GenerateEmpRxFile, to get some random data
-  unsigned bxi;
-  unsigned obx(8);
+  TFile fileout("TCProcessor_EmulationResults.root","recreate");
+  TTree evtstree("Events","Tree");
+  Int_t mod_,link_,address_,col_,evt_;
+  Long64_t energy_;
+  evtstree.Branch("Event", &evt_,"evt_/I");
+  evtstree.Branch("Module", &mod_,"mod_/I");
+  evtstree.Branch("Link", &link_,"link_/I");
+  evtstree.Branch("Address", &address_,"address_/I");
+  evtstree.Branch("Column", &col_,"col_/I");
+  evtstree.Branch("Energy", &energy_,"energy_/L");
 
-  for(unsigned ibx(0);ibx<8;ibx++) { //No messing with bx for test
-    std::cout<<"Bunch crossing "<<ibx<<std::endl;
-    unsigned bx=obx+ibx;
-    //std::cout<<"bx "<<bx<<" obx "<<obx<<" ibx "<<ibx<<std::endl;
+  std::string inputFileName = "data_v11_rx_MsCounter/rx_summary.txt";
 
-    if(bx==0 || bx>=3564) bxi=0xf;
-    else bxi=(bx%8);
+  l1t::demo::BoardData inputs = l1t::demo::read( inputFileName, l1t::demo::FileFormat::EMPv2 );
 
-    //std::cout << "BX loop = " << bx << ", internal " << bxi << std::endl;
-
-    unsigned nConnected=0; //Number of connected lpGBT/unpackers -> this will be used as module number. Works because some lpGBTs not connected at all! 
-    for(unsigned lp(0);lp<TPGStage1Emulation::Stage1IOFwCfg::MaximumLpgbtPairs;lp++) {
-
-      bool connected(false);
-
-      for(unsigned up(0);up<TPGStage1Emulation::Stage1IOFwCfg::MaximumUnpackersPerLpgbtPair;up++) {
-        if(fwCfg.connected(lp,up)) {
-	          connected=true;
-	          //vTc.second.resize(0);
-
-	          TPGFEDataformat::Type type=fwCfg.type(lp,up);
-	          unsigned nTc=fwCfg.numberOfTCs(lp,up);
-
-	          TPGFEModuleEmulation::ECONTEmulation::generateRandomTcRawData(bx,type,nTc,vTc);
-
-            //Print created TCs
-	          /*std::cout << std::endl << "lp,up = " << lp << ", " << up
-		        << ", TCs generated" << std::endl;
-            vTc.print();*/
-
-            //Now pass the randomly created data to the unpacker. 
-            //Doing this in a slightly dumb way (always convert immediately after creating the data, and append to a vector)
-            TPGStage1Emulation::Stage1IO::convertTcRawDataToUnpackerOutputStreamPair(bxi,vTc,theOSP);
-            theOSP.setModuleId(nConnected);
-            theOutputStreams.push_back(theOSP);
-            nConnected+=1;
-	      }
-
+  auto nChannels = inputs.size();
+  std::vector<unsigned int> channel_ids;
+  for ( const auto& channel : inputs ) {
+      channel_ids.push_back(channel.first);
+  }
+  uint32_t elinks[128][290][4]; //128 events, 290 modules, maximum of 4 elinks
+  for(unsigned int nChn = 0; nChn<(channel_ids.size()/2); nChn+=1){
+      unsigned thechnnr = channel_ids.at(2*nChn);
+      for (unsigned int iEvt=0; iEvt < 128 ; iEvt++){
+        assert(inputs.at(thechnnr).at(iEvt*8).startOfPacket);
+        elinks[iEvt][nChn*5+0][0] = inputs.at(thechnnr).at(iEvt*8+0).data;
+        elinks[iEvt][nChn*5+2][1] = inputs.at(thechnnr+1).at(iEvt*8+0).data;
+        elinks[iEvt][nChn*5+0][1] = inputs.at(thechnnr).at(iEvt*8+1).data;
+        elinks[iEvt][nChn*5+2][2] = inputs.at(thechnnr+1).at(iEvt*8+1).data;
+        elinks[iEvt][nChn*5+0][2] = inputs.at(thechnnr).at(iEvt*8+2).data;
+        elinks[iEvt][nChn*5+2][3] = inputs.at(thechnnr+1).at(iEvt*8+2).data;
+        elinks[iEvt][nChn*5+0][3] = inputs.at(thechnnr).at(iEvt*8+3).data;
+        elinks[iEvt][nChn*5+3][0] = inputs.at(thechnnr+1).at(iEvt*8+3).data;
+        elinks[iEvt][nChn*5+1][0] = inputs.at(thechnnr).at(iEvt*8+4).data;
+        elinks[iEvt][nChn*5+3][1] = inputs.at(thechnnr+1).at(iEvt*8+4).data;
+        elinks[iEvt][nChn*5+1][1] = inputs.at(thechnnr).at(iEvt*8+5).data;
+        elinks[iEvt][nChn*5+4][0] = inputs.at(thechnnr+1).at(iEvt*8+5).data;
+        elinks[iEvt][nChn*5+2][0] = inputs.at(thechnnr).at(iEvt*8+6).data;
+        elinks[iEvt][nChn*5+4][1] = inputs.at(thechnnr+1).at(iEvt*8+6).data;
       }
-
-    }
-
-    //Convert unpacker output to standalone HGCal trigger cells
-    l1thgcfirmware::HGCalTriggerCellSACollection theTCsFromOS;
-    theTCsFromOS = convertOSPToTCs(theOutputStreams);
- 
-    //Configure mapping (should match Florence's configuration)
-    l1thgcfirmware::HGCalLayer1PhiOrderFwConfig theConfiguration_;
-    theConfiguration_.configureTestSetupMappingInfo();
-    theConfiguration_.configureTestSetupTDAQReadoutInfo();
-
-    l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_SA;
-    l1thgcfirmware::HGCalLayer1PhiOrderFwImpl theAlgo_;
-
-    //Run TC processor
-    unsigned error_code = theAlgo_.run(theTCsFromOS, theConfiguration_, tcs_out_SA);
-
-    total_error_code+=error_code;
-
-    std::cout<<"Printing TCs with column, channel, frame mapping"<<std::endl;
-    for (auto& tcobj : tcs_out_SA){
-      std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
-    }
-
   }
 
+    for(unsigned int iEvt = 0; iEvt <128 ;iEvt++){
+      std::vector<TPGBEDataformat::UnpackerOutputStreamPair> theOutputStreams;
+      if(doPrint)
+      std::cout<<"==========EVENT "<<iEvt<<"==========="<<std::endl;
+      evt_ = iEvt;
+      for(unsigned int iMod=0; iMod<290; iMod++){
+        TPGFEDataformat::TcRawDataPacket vTc;
+        TPGBEDataformat::UnpackerOutputStreamPair theOSP;
+        if(iMod%5==0){
+           TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, 9, elinks[iEvt][iMod], vTc);
+        } else if (iMod%5==1){
+           TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::BestC, 4, elinks[iEvt][iMod], vTc);
+        } else if (iMod%5==2){
+           TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC4A, 12, elinks[iEvt][iMod], vTc);
+        } else if (iMod%5==3){
+           TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, 3, elinks[iEvt][iMod], vTc);
+        } else if (iMod%5==4){
+           TPGStage1Emulation::Stage1IO::convertElinksToTcRawData(TPGFEDataformat::STC16, 3, elinks[iEvt][iMod], vTc);
+        }
+        TPGStage1Emulation::Stage1IO::convertTcRawDataToUnpackerOutputStreamPair(1,vTc,theOSP);
+        theOSP.setModuleId(iMod);
+        theOutputStreams.push_back(theOSP);
+      }
+        
+      //Convert unpacker output to standalone HGCal trigger cells
+      l1thgcfirmware::HGCalTriggerCellSACollection theTCsFromOS;
+      theTCsFromOS = convertOSPToTCs(theOutputStreams);
+    
+      //Configure mapping (should match Florence's configuration)
+      l1thgcfirmware::HGCalLayer1PhiOrderFwConfig theConfiguration_;
+      theConfiguration_.configureTestSetupMappingInfo();
+      theConfiguration_.configureTestSetupTDAQReadoutInfo();
+  
+      l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_SA;
+      l1thgcfirmware::HGCalLayer1PhiOrderFwImpl theAlgo_;
+
+      //Run TC processor
+      unsigned error_code = theAlgo_.run(theTCsFromOS, theConfiguration_, tcs_out_SA);
+  
+      total_error_code+=error_code;
+  
+      if(doPrint)
+      std::cout<<"Printing TCs with column, channel, frame mapping"<<std::endl;
+      for (auto& tcobj : tcs_out_SA){
+	if(doPrint)
+        std::cout<<"Mod ID "<<tcobj.moduleId()<<" address "<<tcobj.phi()<<" energy "<<tcobj.energy()<<" col "<<tcobj.column()<<" chn "<<tcobj.channel()<<" frame "<<tcobj.frame()<<std::endl;
+	mod_=tcobj.moduleId();
+	address_=tcobj.phi();
+	energy_=tcobj.energy();
+	col_=tcobj.column();
+	link_=channel_ids.at(2*(mod_/5));//This is the start
+	evtstree.Fill();
+      }
+    }
+evtstree.Write();
 return total_error_code;
 }
 


### PR DESCRIPTION
As per the title.

Note this is for the version with 58 lpGBT pairs (that is what the output file corresponds to). The code reads the elink data from the `rx` files provided by raghu (see mattermost), runs the TC processor emulator (after converting the elink data). The output is a flat root tree which stores the event number, module number, address, energy, column, and the first channel ID of the lpGBT link pair. 